### PR TITLE
Make compilation event-loop friendly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-jit",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "GraphQL JIT Compiler to JS",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "graphql-tools": "^4.0.4",
     "jest": "^24.7.1",
     "lint-staged": "^8.1.5",
+    "metrics": "^0.1.21",
     "prettier": "^1.16.4",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.0.3",

--- a/src/__tests__/abstract.test.ts
+++ b/src/__tests__/abstract.test.ts
@@ -15,9 +15,9 @@ import {
 } from "graphql";
 import { compileQuery } from "../index";
 
-function graphql(schema: GraphQLSchema, query: string) {
+async function graphql(schema: GraphQLSchema, query: string) {
   const ast = parse(query);
-  const compiled: any = compileQuery(schema, ast, "");
+  const compiled: any = await compileQuery(schema, ast, "");
   return compiled.query(undefined, undefined, {});
 }
 
@@ -35,7 +35,7 @@ class Human {
 
 // tslint:disable-next-line
 describe("Execute: Handles execution of abstract types", () => {
-  test("isTypeOf used to resolve runtime type for Interface", () => {
+  test("isTypeOf used to resolve runtime type for Interface", async () => {
     const PetType = new GraphQLInterfaceType({
       name: "Pet",
       fields: {
@@ -90,7 +90,7 @@ describe("Execute: Handles execution of abstract types", () => {
       }
     }`;
 
-    const result = graphql(schema, query);
+    const result = await graphql(schema, query);
 
     expect(result).toEqual({
       data: {
@@ -108,7 +108,7 @@ describe("Execute: Handles execution of abstract types", () => {
     });
   });
 
-  test("isTypeOf used to resolve runtime type for Union", () => {
+  test("isTypeOf used to resolve runtime type for Union", async () => {
     const DogType = new GraphQLObjectType({
       name: "Dog",
       isTypeOf: obj => obj instanceof Dog,
@@ -159,7 +159,7 @@ describe("Execute: Handles execution of abstract types", () => {
       }
     }`;
 
-    const result = graphql(schema, query);
+    const result = await graphql(schema, query);
 
     expect(result).toEqual({
       data: {
@@ -177,7 +177,7 @@ describe("Execute: Handles execution of abstract types", () => {
     });
   });
 
-  test("resolveType on Interface yields useful error", () => {
+  test("resolveType on Interface yields useful error", async () => {
     const PetType: GraphQLInterfaceType = new GraphQLInterfaceType({
       name: "Pet",
       resolveType(obj) {
@@ -250,7 +250,7 @@ describe("Execute: Handles execution of abstract types", () => {
       }
     }`;
 
-    const result = graphql(schema, query);
+    const result = await graphql(schema, query);
 
     expect(result).toEqual({
       data: {
@@ -277,7 +277,7 @@ describe("Execute: Handles execution of abstract types", () => {
     });
   });
 
-  test("resolveType on Union yields useful error", () => {
+  test("resolveType on Union yields useful error", async () => {
     const HumanType = new GraphQLObjectType({
       name: "Human",
       fields: {
@@ -348,7 +348,7 @@ describe("Execute: Handles execution of abstract types", () => {
       }
     }`;
 
-    const result = graphql(schema, query);
+    const result = await graphql(schema, query);
 
     expect(result).toEqual({
       data: {
@@ -375,7 +375,7 @@ describe("Execute: Handles execution of abstract types", () => {
     });
   });
 
-  test("returning invalid value from resolveType yields useful error", () => {
+  test("returning invalid value from resolveType yields useful error", async () => {
     const fooInterface = new GraphQLInterfaceType({
       name: "FooInterface",
       fields: { bar: { type: GraphQLString } },
@@ -401,7 +401,7 @@ describe("Execute: Handles execution of abstract types", () => {
       types: [fooObject]
     });
 
-    const result = graphql(schema, "{ foo { bar } }");
+    const result = await graphql(schema, "{ foo { bar } }");
 
     expect(result).toEqual({
       data: { foo: null },
@@ -419,7 +419,7 @@ describe("Execute: Handles execution of abstract types", () => {
     });
   });
 
-  test("resolveType allows resolving with type name", () => {
+  test("resolveType allows resolving with type name", async () => {
     const PetType = new GraphQLInterfaceType({
       name: "Pet",
       resolveType(obj) {
@@ -475,7 +475,7 @@ describe("Execute: Handles execution of abstract types", () => {
       }
     }`;
 
-    const result = graphql(schema, query);
+    const result = await graphql(schema, query);
 
     expect(result).toEqual({
       data: {

--- a/src/__tests__/alias.test.ts
+++ b/src/__tests__/alias.test.ts
@@ -14,13 +14,13 @@ import {
 } from "graphql";
 import { compileQuery } from "../index";
 
-function executeQuery(
+async function executeQuery(
   schema: GraphQLSchema,
   document: DocumentNode,
   rootValue?: any,
   vars?: any
 ) {
-  const prepared: any = compileQuery(schema, document, "");
+  const prepared: any = await compileQuery(schema, document, "");
   return prepared.query(rootValue, undefined, vars);
 }
 

--- a/src/__tests__/defer.test.ts
+++ b/src/__tests__/defer.test.ts
@@ -1,0 +1,15 @@
+import { defer } from "../defer";
+
+describe("defer", () => {
+  test("will return result", async () => {
+    expect(await defer(() => "test")).toEqual("test");
+  });
+  test("will throw the original error", async () => {
+    const err = new Error("bad");
+    return expect(
+      defer(() => {
+        throw err;
+      })
+    ).rejects.toBe(err);
+  });
+});

--- a/src/__tests__/directives.test.ts
+++ b/src/__tests__/directives.test.ts
@@ -32,17 +32,17 @@ const schema = new GraphQLSchema({
 
 const data = {};
 
-function executeTestQuery(query: string) {
+async function executeTestQuery(query: string) {
   const ast = parse(query);
-  const compiled: any = compileQuery(schema, ast, "");
+  const compiled: any = await compileQuery(schema, ast, "");
   return compiled.query(data, undefined, {});
 }
 
 // tslint:disable-next-line
 describe("Execute: handles directives", () => {
   describe("works without directives", () => {
-    test("basic query works", () => {
-      const result = executeTestQuery("{ a, b }");
+    test("basic query works", async () => {
+      const result = await executeTestQuery("{ a, b }");
 
       expect(result).toEqual({
         data: { a: "a", b: "b" }
@@ -52,16 +52,16 @@ describe("Execute: handles directives", () => {
 
   describe("works on scalars", () => {
     // tslint:disable-next-line
-    test("if true includes scalar", () => {
-      const result = executeTestQuery("{ a, b @include(if: true) }");
+    test("if true includes scalar", async () => {
+      const result = await executeTestQuery("{ a, b @include(if: true) }");
 
       expect(result).toEqual({
         data: { a: "a", b: "b" }
       });
     });
 
-    test("if false omits on scalar", () => {
-      const result = executeTestQuery("{ a, b @include(if: false) }");
+    test("if false omits on scalar", async () => {
+      const result = await executeTestQuery("{ a, b @include(if: false) }");
 
       expect(result).toEqual({
         data: { a: "a" }
@@ -69,8 +69,8 @@ describe("Execute: handles directives", () => {
     });
 
     // tslint:disable-next-line
-    test("unless false includes scalar", () => {
-      const result = executeTestQuery("{ a, b @skip(if: false) }");
+    test("unless false includes scalar", async () => {
+      const result = await executeTestQuery("{ a, b @skip(if: false) }");
 
       expect(result).toEqual({
         data: { a: "a", b: "b" }
@@ -78,8 +78,8 @@ describe("Execute: handles directives", () => {
     });
 
     // tslint:disable-next-line
-    test("unless true omits scalar", () => {
-      const result = executeTestQuery("{ a, b @skip(if: true) }");
+    test("unless true omits scalar", async () => {
+      const result = await executeTestQuery("{ a, b @skip(if: true) }");
 
       expect(result).toEqual({
         data: { a: "a" }
@@ -88,8 +88,8 @@ describe("Execute: handles directives", () => {
   });
 
   describe("works on fragment spreads", () => {
-    test("if false omits fragment spread", () => {
-      const result = executeTestQuery(`
+    test("if false omits fragment spread", async () => {
+      const result = await executeTestQuery(`
         query {
           a
           ...Frag @include(if: false)
@@ -104,8 +104,8 @@ describe("Execute: handles directives", () => {
       });
     });
 
-    test("if true includes fragment spread", () => {
-      const result = executeTestQuery(`
+    test("if true includes fragment spread", async () => {
+      const result = await executeTestQuery(`
         query {
           a
           ...Frag @include(if: true)
@@ -120,8 +120,8 @@ describe("Execute: handles directives", () => {
       });
     });
 
-    test("unless false includes fragment spread", () => {
-      const result = executeTestQuery(`
+    test("unless false includes fragment spread", async () => {
+      const result = await executeTestQuery(`
         query {
           a
           ...Frag @skip(if: false)
@@ -136,8 +136,8 @@ describe("Execute: handles directives", () => {
       });
     });
 
-    test("unless true omits fragment spread", () => {
-      const result = executeTestQuery(`
+    test("unless true omits fragment spread", async () => {
+      const result = await executeTestQuery(`
         query {
           a
           ...Frag @skip(if: true)
@@ -154,8 +154,8 @@ describe("Execute: handles directives", () => {
   });
 
   describe("works on inline fragment", () => {
-    test("if false omits inline fragment", () => {
-      const result = executeTestQuery(`
+    test("if false omits inline fragment", async () => {
+      const result = await executeTestQuery(`
         query {
           a
           ... on TestType @include(if: false) {
@@ -169,8 +169,8 @@ describe("Execute: handles directives", () => {
       });
     });
 
-    test("if true includes inline fragment", () => {
-      const result = executeTestQuery(`
+    test("if true includes inline fragment", async () => {
+      const result = await executeTestQuery(`
         query {
           a
           ... on TestType @include(if: true) {
@@ -183,8 +183,8 @@ describe("Execute: handles directives", () => {
         data: { a: "a", b: "b" }
       });
     });
-    test("unless false includes inline fragment", () => {
-      const result = executeTestQuery(`
+    test("unless false includes inline fragment", async () => {
+      const result = await executeTestQuery(`
         query {
           a
           ... on TestType @skip(if: false) {
@@ -197,8 +197,8 @@ describe("Execute: handles directives", () => {
         data: { a: "a", b: "b" }
       });
     });
-    test("unless true includes inline fragment", () => {
-      const result = executeTestQuery(`
+    test("unless true includes inline fragment", async () => {
+      const result = await executeTestQuery(`
         query {
           a
           ... on TestType @skip(if: true) {
@@ -214,8 +214,8 @@ describe("Execute: handles directives", () => {
   });
 
   describe("works on anonymous inline fragment", () => {
-    test("if false omits anonymous inline fragment", () => {
-      const result = executeTestQuery(`
+    test("if false omits anonymous inline fragment", async () => {
+      const result = await executeTestQuery(`
         query {
           a
           ... @include(if: false) {
@@ -229,8 +229,8 @@ describe("Execute: handles directives", () => {
       });
     });
 
-    test("if true includes anonymous inline fragment", () => {
-      const result = executeTestQuery(`
+    test("if true includes anonymous inline fragment", async () => {
+      const result = await executeTestQuery(`
         query {
           a
           ... @include(if: true) {
@@ -243,8 +243,8 @@ describe("Execute: handles directives", () => {
         data: { a: "a", b: "b" }
       });
     });
-    test("unless false includes anonymous inline fragment", () => {
-      const result = executeTestQuery(`
+    test("unless false includes anonymous inline fragment", async () => {
+      const result = await executeTestQuery(`
         query Q {
           a
           ... @skip(if: false) {
@@ -257,8 +257,8 @@ describe("Execute: handles directives", () => {
         data: { a: "a", b: "b" }
       });
     });
-    test("unless true includes anonymous inline fragment", () => {
-      const result = executeTestQuery(`
+    test("unless true includes anonymous inline fragment", async () => {
+      const result = await executeTestQuery(`
         query {
           a
           ... @skip(if: true) {
@@ -274,8 +274,8 @@ describe("Execute: handles directives", () => {
   });
 
   describe("works with skip and include directives", () => {
-    test("include and no skip", () => {
-      const result = executeTestQuery(`
+    test("include and no skip", async () => {
+      const result = await executeTestQuery(`
         {
           a
           b @include(if: true) @skip(if: false)
@@ -287,8 +287,8 @@ describe("Execute: handles directives", () => {
       });
     });
 
-    test("include and skip", () => {
-      const result = executeTestQuery(`
+    test("include and skip", async () => {
+      const result = await executeTestQuery(`
         {
           a
           b @include(if: true) @skip(if: true)
@@ -300,8 +300,8 @@ describe("Execute: handles directives", () => {
       });
     });
 
-    test("no include or skip", () => {
-      const result = executeTestQuery(`
+    test("no include or skip", async () => {
+      const result = await executeTestQuery(`
         {
           a
           b @include(if: false) @skip(if: false)

--- a/src/__tests__/error.test.ts
+++ b/src/__tests__/error.test.ts
@@ -27,50 +27,50 @@ const schema = new GraphQLSchema({
   })
 });
 
-function executeTestQuery(
+async function executeTestQuery(
   query: string,
   disablingCapturingStackErrors: boolean,
   root: any = {}
 ) {
   const ast = parse(query);
-  const compiled: any = compileQuery(schema, ast, "", {
+  const compiled: any = await compileQuery(schema, ast, "", {
     disablingCapturingStackErrors
   });
   return compiled.query(root, undefined, {});
 }
 
 describe("error generation", () => {
-  test("includes original error", () => {
+  test("includes original error", async () => {
     const error = new Error("original");
-    const resp = executeTestQuery("{ b }", false, { b: error });
+    const resp = await executeTestQuery("{ b }", false, { b: error });
     expect(resp.errors[0].originalError).toBe(error);
   });
-  test("is instanceOf upstream error", () => {
-    const resp = executeTestQuery("{ b }", false, { b: new Error() });
+  test("is instanceOf upstream error", async () => {
+    const resp = await executeTestQuery("{ b }", false, { b: new Error() });
     expect(resp.errors[0] instanceof GraphQLError).toBeTruthy();
     expect(resp.errors[0] instanceof Error).toBeTruthy();
   });
   describe("stack capture", () => {
-    test("capture the stack", () => {
+    test("capture the stack", async () => {
       const error = "test";
-      const resp = executeTestQuery("{ b }", false, { b: error });
+      const resp = await executeTestQuery("{ b }", false, { b: error });
       expect(resp.errors[0].originalError).toBe(error);
       expect(resp.errors[0].stack).toBeDefined();
     });
-    test("copies the stack if available", () => {
-      const resp = executeTestQuery("{ b }", true, { b: new Error() });
+    test("copies the stack if available", async () => {
+      const resp = await executeTestQuery("{ b }", true, { b: new Error() });
       expect(resp.errors[0].stack).toBeDefined();
     });
-    test("does not capture the stack if set in options", () => {
+    test("does not capture the stack if set in options", async () => {
       const error = "test";
-      const resp = executeTestQuery("{ b }", true, { b: error });
+      const resp = await executeTestQuery("{ b }", true, { b: error });
       expect(resp.errors[0].originalError).toBe(error);
       expect(resp.errors[0].stack).not.toBeDefined();
     });
-    test("fallbacks if Error.captureStackTrace is not defined", () => {
+    test("fallbacks if Error.captureStackTrace is not defined", async () => {
       const captureStackTrace = Error.captureStackTrace;
       Error.captureStackTrace = (null as unknown) as any;
-      const resp = executeTestQuery("{ b }", false, { b: "error" });
+      const resp = await executeTestQuery("{ b }", false, { b: "error" });
       expect(resp.errors[0].stack).toBeDefined();
       Error.captureStackTrace = captureStackTrace;
     });

--- a/src/__tests__/execution.test.ts
+++ b/src/__tests__/execution.test.ts
@@ -42,7 +42,7 @@ function executeArgs(args: any) {
   );
 }
 
-function executeQuery(
+async function executeQuery(
   schema?: GraphQLSchema,
   document?: DocumentNode,
   rootValue?: any,
@@ -50,7 +50,7 @@ function executeQuery(
   variableValues?: any,
   operationName?: string
 ) {
-  const prepared: any = compileQuery(
+  const prepared: any = await compileQuery(
     schema as any,
     document as any,
     operationName || ""
@@ -150,15 +150,17 @@ describe("Execute: Handles basic execution tasks", () => {
       })
     });
 
-    expect(() => executeQuery(schema)).toThrow("Must provide document");
+    return expect(executeQuery(schema)).rejects.toThrow(
+      "Must provide document"
+    );
   });
 
   test("throws if no schema is provided", async () => {
-    expect(() =>
+    return expect(
       executeArgs({
         document: parse("{ field }")
       })
-    ).toThrow("Expected undefined to be a GraphQL schema.");
+    ).rejects.toThrow("Expected undefined to be a GraphQL schema.");
   });
 
   test("accepts an object with named properties as arguments", async () => {
@@ -217,7 +219,7 @@ describe("Execute: Handles basic execution tasks", () => {
     });
     const schema = new GraphQLSchema({ query: Type });
 
-    expect(executeQuery(schema, ast)).toEqual({
+    expect(await executeQuery(schema, ast)).toEqual({
       data: {
         a: "Apple",
         b: "Banana",
@@ -255,7 +257,7 @@ describe("Execute: Handles basic execution tasks", () => {
 
     const rootValue = { root: "val" };
 
-    executeQuery(schema, ast, rootValue, null, { var: "abc" });
+    await executeQuery(schema, ast, rootValue, null, { var: "abc" });
 
     expect(Object.keys(info)).toEqual([
       "fieldName",
@@ -340,7 +342,7 @@ describe("Execute: Handles basic execution tasks", () => {
       })
     });
 
-    executeQuery(schema, parse(doc));
+    await executeQuery(schema, parse(doc));
 
     expect(resolvedArgs.numArg).toEqual(123);
     expect(resolvedArgs.stringArg).toEqual("foo");
@@ -785,7 +787,7 @@ describe("Execute: Handles basic execution tasks", () => {
       })
     });
 
-    expect(executeQuery(schema, ast, data)).toEqual({
+    expect(await executeQuery(schema, ast, data)).toEqual({
       errors: [{ message: "Must provide an operation." }]
     });
   });
@@ -804,7 +806,7 @@ describe("Execute: Handles basic execution tasks", () => {
       })
     });
 
-    expect(executeQuery(schema, ast, data)).toEqual({
+    expect(await executeQuery(schema, ast, data)).toEqual({
       errors: [
         {
           message:
@@ -827,7 +829,7 @@ describe("Execute: Handles basic execution tasks", () => {
     });
 
     expect(
-      executeArgs({
+      await executeArgs({
         schema,
         document: ast,
         operationName: "UnknownExample"

--- a/src/__tests__/json.test.ts
+++ b/src/__tests__/json.test.ts
@@ -10,8 +10,7 @@ import {
   GraphQLSchema,
   GraphQLString,
   parse,
-  GraphQLInt,
-  GraphQLScalarType
+  GraphQLInt
 } from "graphql";
 import { buildExecutionContext } from "graphql/execution/execute";
 import { compileQuery } from "../index";
@@ -147,7 +146,7 @@ describe("json schema creator", () => {
       expect(typeof fastJson(jsonSchema) === "function").toBeTruthy();
     });
     test("valid response serialization", async () => {
-      const prepared: any = compileQuery(blogSchema, parse(query), "", {
+      const prepared: any = await compileQuery(blogSchema, parse(query), "", {
         customJSONSerializer: true
       });
       const response = await prepared.query(undefined, undefined, {});
@@ -155,7 +154,7 @@ describe("json schema creator", () => {
       expect(prepared.stringify(response)).toEqual(JSON.stringify(response));
     });
     test("valid response serialization 2", async () => {
-      const prepared: any = compileQuery(blogSchema, parse(query), "", {
+      const prepared: any = await compileQuery(blogSchema, parse(query), "", {
         customJSONSerializer: false
       });
       expect(prepared.stringify).toBe(JSON.stringify);

--- a/src/__tests__/mutations.test.ts
+++ b/src/__tests__/mutations.test.ts
@@ -100,12 +100,12 @@ const schema = new GraphQLSchema({
   })
 });
 
-function executeQuery(
+async function executeQuery(
   schema: GraphQLSchema,
   document: DocumentNode,
   rootValue: any
 ) {
-  const { query }: any = compileQuery(schema, document, "");
+  const { query }: any = await compileQuery(schema, document, "");
   return query(rootValue, undefined, {});
 }
 

--- a/src/__tests__/nonnull.test.ts
+++ b/src/__tests__/nonnull.test.ts
@@ -127,7 +127,7 @@ function executeArgs(args: any) {
   );
 }
 
-function doExecute(
+async function doExecute(
   schema: GraphQLSchema,
   document: DocumentNode,
   rootValue: any,
@@ -135,7 +135,11 @@ function doExecute(
   variableValues?: any,
   operationName?: string
 ) {
-  const prepared: any = compileQuery(schema, document, operationName || "");
+  const prepared: any = await compileQuery(
+    schema,
+    document,
+    operationName || ""
+  );
   if (prepared.errors) {
     return prepared;
   }

--- a/src/__tests__/resolve-info.test.ts
+++ b/src/__tests__/resolve-info.test.ts
@@ -1060,7 +1060,7 @@ describe("GraphQLJitResolveInfo", () => {
   });
 });
 
-function executeQuery(
+async function executeQuery(
   schema?: GraphQLSchema,
   document?: DocumentNode,
   rootValue?: any,
@@ -1068,7 +1068,7 @@ function executeQuery(
   variableValues?: any,
   operationName?: string
 ) {
-  const prepared: any = compileQuery(
+  const prepared: any = await compileQuery(
     schema as any,
     document as any,
     operationName || ""

--- a/src/__tests__/resolve.test.ts
+++ b/src/__tests__/resolve.test.ts
@@ -12,7 +12,7 @@ import {
 import { GraphQLFieldConfig } from "graphql/type/definition";
 import { compileQuery } from "../index";
 
-function executeQuery(
+async function executeQuery(
   schema: GraphQLSchema,
   document: string,
   rootValue?: any,
@@ -20,7 +20,7 @@ function executeQuery(
   variableValues?: any,
   operationName?: string
 ) {
-  const { query }: any = compileQuery(
+  const { query }: any = await compileQuery(
     schema,
     parse(document),
     operationName || ""

--- a/src/__tests__/scalars.test.ts
+++ b/src/__tests__/scalars.test.ts
@@ -10,13 +10,13 @@ import {
 import { compileQuery } from "../index";
 import SpyInstance = jest.SpyInstance;
 
-function executeQuery(
+async function executeQuery(
   schema: GraphQLSchema,
   document: DocumentNode,
   rootValue?: any,
   vars?: any
 ) {
-  const prepared: any = compileQuery(schema, document, "");
+  const prepared: any = await compileQuery(schema, document, "");
   return prepared.query(rootValue, undefined, vars);
 }
 
@@ -157,9 +157,9 @@ describe("Scalars: Is able to serialize custom scalar", () => {
   });
 
   describe("can skip serialization", () => {
-    test("custom scalar are still supported", () => {
+    test("custom scalar are still supported", async () => {
       const spy = jest.fn((value: any) => value);
-      const prepared: any = compileQuery(
+      const prepared: any = await compileQuery(
         setupSchema(
           new GraphQLScalarType({
             name: "Custom",
@@ -190,8 +190,8 @@ describe("Scalars: Is able to serialize custom scalar", () => {
         serializeSpy.mockClear();
       });
 
-      test("builtin scalar are used", () => {
-        const prepared: any = compileQuery(
+      test("builtin scalar are used", async () => {
+        const prepared: any = await compileQuery(
           setupSchema(GraphQLString, "test"),
           parse("{scalar}"),
           "",
@@ -205,8 +205,8 @@ describe("Scalars: Is able to serialize custom scalar", () => {
         });
         expect(GraphQLString.serialize).toHaveBeenCalledWith("test");
       });
-      test("builtin scalar are skipped", () => {
-        const prepared: any = compileQuery(
+      test("builtin scalar are skipped", async () => {
+        const prepared: any = await compileQuery(
           setupSchema(GraphQLString, "test"),
           parse("{scalar}"),
           "",
@@ -220,9 +220,9 @@ describe("Scalars: Is able to serialize custom scalar", () => {
         });
         expect(GraphQLString.serialize).not.toHaveBeenCalledWith("test");
       });
-      test("custom serializer is called", () => {
+      test("custom serializer is called", async () => {
         const customSerializer = jest.fn(String);
-        const prepared: any = compileQuery(
+        const prepared: any = await compileQuery(
           setupSchema(GraphQLString, "test"),
           parse("{scalar}"),
           "",

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -18,8 +18,8 @@ import {
 } from "graphql";
 import { compileQuery } from "../index";
 
-function executeQuery(schema: GraphQLSchema, document: DocumentNode) {
-  const prepared: any = compileQuery(schema, document, "");
+async function executeQuery(schema: GraphQLSchema, document: DocumentNode) {
+  const prepared: any = await compileQuery(schema, document, "");
   return prepared.query(undefined, undefined, undefined);
 }
 
@@ -393,9 +393,9 @@ describe("Execute: Handles execution with a complex schema", () => {
     });
   });
 
-  test("executes IntrospectionQuery", () => {
+  test("executes IntrospectionQuery", async () => {
     const queryAST = parse(getIntrospectionQuery({ descriptions: true }));
-    const result = executeQuery(BlogSchema, queryAST);
+    const result = await executeQuery(BlogSchema, queryAST);
     expect(result).toMatchSnapshot();
   });
 });

--- a/src/__tests__/union-interface.test.ts
+++ b/src/__tests__/union-interface.test.ts
@@ -31,13 +31,13 @@ class Person {
   ) {}
 }
 
-function execute(
+async function execute(
   schema: GraphQLSchema,
   document: DocumentNode,
   root?: any,
   context?: any
 ) {
-  const { query, errors }: any = compileQuery(schema, document, "");
+  const { query }: any = await compileQuery(schema, document, "");
   return query(root, context, {});
 }
 
@@ -105,7 +105,7 @@ const john = new Person("John", [garfield, odie], [liz, odie]);
 
 // tslint:disable-next-line
 describe("Execute: Union and intersection types", () => {
-  test("can introspect on union and intersection types", () => {
+  test("can introspect on union and intersection types", async () => {
     const ast = parse(`
       {
         Named: __type(name: "Named") {
@@ -129,7 +129,7 @@ describe("Execute: Union and intersection types", () => {
       }
     `);
 
-    expect(execute(schema, ast)).toEqual({
+    expect(await execute(schema, ast)).toEqual({
       data: {
         Named: {
           kind: "INTERFACE",
@@ -153,7 +153,7 @@ describe("Execute: Union and intersection types", () => {
     });
   });
 
-  test("executes union types with inline fragments", () => {
+  test("executes union types with inline fragments", async () => {
     // This is the valid version of the query in the above test.
     const ast = parse(`
       {
@@ -173,7 +173,7 @@ describe("Execute: Union and intersection types", () => {
       }
     `);
 
-    expect(execute(schema, ast, john)).toEqual({
+    expect(await execute(schema, ast, john)).toEqual({
       data: {
         __typename: "Person",
         name: "John",
@@ -185,7 +185,7 @@ describe("Execute: Union and intersection types", () => {
     });
   });
 
-  test("executes union types with inline fragments", () => {
+  test("executes union types with inline fragments", async () => {
     // This is the valid version of the query in the above test.
     const ast = parse(`
       {
@@ -204,7 +204,7 @@ describe("Execute: Union and intersection types", () => {
       }
     `);
 
-    expect(execute(schema, ast, john)).toEqual({
+    expect(await execute(schema, ast, john)).toEqual({
       data: {
         __typename: "Person",
         name: "John",
@@ -216,7 +216,7 @@ describe("Execute: Union and intersection types", () => {
     });
   });
 
-  test("allows fragment conditions to be abstract types", () => {
+  test("allows fragment conditions to be abstract types", async () => {
     const ast = parse(`
       {
         __typename
@@ -249,7 +249,7 @@ describe("Execute: Union and intersection types", () => {
       }
     `);
 
-    expect(execute(schema, ast, john)).toEqual({
+    expect(await execute(schema, ast, john)).toEqual({
       data: {
         __typename: "Person",
         name: "John",
@@ -265,7 +265,7 @@ describe("Execute: Union and intersection types", () => {
     });
   });
 
-  test("gets execution info in resolver", () => {
+  test("gets execution info in resolver", async () => {
     let encounteredContext;
     let encounteredSchema;
     let encounteredRootValue;
@@ -302,7 +302,7 @@ describe("Execute: Union and intersection types", () => {
 
     const ast = parse("{ name, friends { name } }");
 
-    expect(execute(schema2, ast, john2, context)).toEqual({
+    expect(await execute(schema2, ast, john2, context)).toEqual({
       data: { name: "John", friends: [{ name: "Liz" }] }
     });
 

--- a/src/__tests__/variables.test.ts
+++ b/src/__tests__/variables.test.ts
@@ -148,9 +148,9 @@ const TestType = new GraphQLObjectType({
 
 const schema = new GraphQLSchema({ query: TestType });
 
-function executeQuery(query: string, variableValues?: any) {
+async function executeQuery(query: string, variableValues?: any) {
   const document = parse(query);
-  const prepared: any = compileQuery(schema, document, "");
+  const prepared: any = await compileQuery(schema, document, "");
   if (prepared.errors) {
     return prepared;
   }
@@ -460,7 +460,7 @@ describe("Execute: Handles inputs", () => {
 
   describe("Handles custom enum values", () => {
     test("allows custom enum values as inputs", async () => {
-      const result = executeQuery(`
+      const result = await executeQuery(`
         {
           null: fieldWithEnumInput(input: NULL)
           NaN: fieldWithEnumInput(input: NAN)
@@ -732,7 +732,7 @@ describe("Execute: Handles inputs", () => {
           inputRecorder(input: $string)
         }
       `;
-      const compiled: any = compileQuery(schema, parse(document), "");
+      const compiled: any = await compileQuery(schema, parse(document), "");
       compiled.query(undefined, undefined, { string: "id" });
       expect(spy).toHaveBeenCalledWith(
         undefined,

--- a/src/defer.ts
+++ b/src/defer.ts
@@ -1,0 +1,11 @@
+export function defer<T>(f: () => T): Promise<T> {
+  return new Promise((resolve, reject) => {
+    setImmediate(() => {
+      try {
+        resolve(f());
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1339,6 +1339,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
   integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
 
+events@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-2.1.0.tgz#2a9a1e18e6106e0e812aa9ebd4a819b3c29c0ba5"
+  integrity sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==
+
 exec-sh@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.2.tgz#6738de2eb7c8e671d0366aea0b0db8c6f7d7391b"
@@ -2915,6 +2920,13 @@ merge-stream@^1.0.1:
   integrity sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=
   dependencies:
     readable-stream "^2.0.1"
+
+metrics@^0.1.21:
+  version "0.1.21"
+  resolved "https://registry.yarnpkg.com/metrics/-/metrics-0.1.21.tgz#e3d3c6e8deb527f1a3c49d64c50e643e05338ac8"
+  integrity sha512-Lg/0Kj7fani6FDmlC99glxpPjK3GHzE50Hp6IVIaMhGc9ZxR2MF0Eo4haOl1C0cGWpRkViv45P0hdvRJghkJtQ==
+  dependencies:
+    events "^2.0.0"
 
 micromatch@^3.1.10, micromatch@^3.1.4, micromatch@^3.1.8:
   version "3.1.10"


### PR DESCRIPTION
It will no longer hold the event loop for a large period of time at the cost of compilation throughput.

Before -  latest master
```
Results
{
    "type": "histogram",
    "min": 20628.938725,
    "max": 20628.938725,
    "sum": 20628.938725,
    "variance": null,
    "mean": 20628.938725,
    "std_dev": null,
    "count": 1,
    "median": 20628.938725,
    "p75": 20628.938725,
    "p95": 20628.938725,
    "p99": 20628.938725,
    "p999": 20628.938725
}
Total time: 20731.450504ms
```

After - this PR
```
Results
{
    "type": "histogram",
    "min": -0.9916180000000026,
    "max": 18.801353000000006,
    "sum": 110.67938100000002,
    "variance": 3.605352099798751,
    "mean": 0.4729888076923076,
    "std_dev": 1.8987764744168154,
    "count": 234,
    "median": 0.013759999999997774,
    "p75": 0.17402825000000277,
    "p95": 3.3057655000000032,
    "p99": 11.669598050000015,
    "p999": 18.801353000000006
}
Total time: 23558.98034ms
```

Given the single thread nature of NodeJS, this look to be a worthy compromise.