### PR TITLE
bugfix for using 'parent' as field name in SDL

### DIFF
--- a/src/__tests__/execution.test.ts
+++ b/src/__tests__/execution.test.ts
@@ -1198,6 +1198,31 @@ describe("Execute: Handles basic execution tasks", () => {
       }
     });
   });
+
+  test("allow for 'parent' field name", async () => {
+    const query = parse(`{ parent }`);
+
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: "Query",
+        fields: {
+          parent: {
+            type: GraphQLString,
+            resolve() {
+              return "works";
+            }
+          }
+        }
+      })
+    });
+
+    const result = await executeQuery(schema, query, null);
+    expect(result).toEqual({
+      data: {
+        parent: "works"
+      }
+    });
+  });
 });
 
 describe("Checks if the output of the compilation was a compiled query", () => {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -93,6 +93,7 @@ const GLOBAL_ROOT_NAME = "__rootValue";
 const GLOBAL_VARIABLES_NAME = "__variables";
 const GLOBAL_CONTEXT_NAME = "__context";
 const GLOBAL_INSPECT_NAME = "__inspect";
+const GLOBAL_PARENT_NAME = "__parent";
 
 interface DeferredField {
   name: string;
@@ -414,7 +415,7 @@ function compileDeferredFields(context: CompilationContext): string {
         fieldType,
         fieldNodes,
         [fieldName],
-        [`parent.${name}`],
+        [`${GLOBAL_PARENT_NAME}.${name}`],
         responsePath
       );
       const resolverName = getResolverName(parentType.name, fieldName);
@@ -443,7 +444,7 @@ function compileDeferredFields(context: CompilationContext): string {
        fieldNodes,
        responsePath
      )}),
-     (parent, ${fieldName}, err) => {
+     (${GLOBAL_PARENT_NAME}, ${fieldName}, err) => {
       if (err != null) {
           ${
             isNonNullType(fieldType)
@@ -460,7 +461,7 @@ function compileDeferredFields(context: CompilationContext): string {
       });
       }
       ${generateUniqueDeclarations(subContext)}
-      parent.${name} = ${nodeBody};\n
+      ${GLOBAL_PARENT_NAME}.${name} = ${nodeBody};\n
       ${compileDeferredFields(subContext)}
     },${destinationPaths.join(
       "."


### PR DESCRIPTION
Hi,
Currently there is a bug which prevents using string `parent` as a field name in GraphQL schema.

Example:
``` 
type MyType {
  parent: String
}
```

When querying for `parent` field there is an error:
`SyntaxError: Duplicate parameter name not allowed in this context`. 

I addressed this issue by introducing yet another global (`__parent`). Seems to be working fine.