### PR TITLE
Fix benchmarks (graphql-js returns different data than jit counterpart)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ code which yields much better performance.
 
 ```bash
 $ ts-node -T ./src/__benchmarks__/schema.benchmark.ts 
-graphql-js x 3,873 ops/sec ±3.89% (74 runs sampled)
-graphql-jit x 128,301 ops/sec ±1.79% (75 runs sampled)
+graphql-js x 12,315 ops/sec ±4.55% (75 runs sampled)
+graphql-jit x 123,367 ops/sec ±1.13% (81 runs sampled)
 Fastest is graphql-jit
 
 $ ts-node -T ./src/__benchmarks__/schema-many-resolvers.benchmark.ts 
-graphql-js x 5,458 ops/sec ±5.62% (70 runs sampled)
-graphql-jit x 52,345 ops/sec ±3.95% (74 runs sampled)
+graphql-js x 14,006 ops/sec ±2.05% (78 runs sampled)
+graphql-jit x 52,248 ops/sec ±1.36% (81 runs sampled)
 Fastest is graphql-jit
 ```
 

--- a/src/__benchmarks__/schema-many-resolvers.benchmark.ts
+++ b/src/__benchmarks__/schema-many-resolvers.benchmark.ts
@@ -193,7 +193,7 @@ function getSchema() {
   function article(id: number): any {
     return {
       id,
-      isPublished: "true",
+      isPublished: true,
       author: johnSmith,
       title: "My Article " + id,
       body: "This is a post",

--- a/src/__benchmarks__/schema-variables.benchmark.ts
+++ b/src/__benchmarks__/schema-variables.benchmark.ts
@@ -182,7 +182,7 @@ function getSchema() {
   function article(id: number): any {
     return {
       id,
-      isPublished: "true",
+      isPublished: true,
       author: johnSmith,
       title: "My Article " + id,
       body: "This is a post",

--- a/src/__benchmarks__/schema.benchmark.ts
+++ b/src/__benchmarks__/schema.benchmark.ts
@@ -163,7 +163,7 @@ function getSchema() {
   function article(id: number): any {
     return {
       id,
-      isPublished: "true",
+      isPublished: true,
       author: johnSmith,
       title: "My Article " + id,
       body: "This is a post",


### PR DESCRIPTION
graphql-js part returned 'Boolean cannot represent a non boolean value: "true"' error so the benchmark was not fair (the results are still favourable for jit though ;)