### PR TITLE
Remove spreading from the enriching.

### DIFF
--- a/src/__benchmarks__/schema-many-resolvers.benchmark.ts
+++ b/src/__benchmarks__/schema-many-resolvers.benchmark.ts
@@ -18,15 +18,18 @@ const schema = getSchema();
 const document = parse(`
 {
   feed {
+    __typename
     id,
     title
   },
   article(id: "1") {
     ...articleFields,
     author {
+      __typename
       id,
       name,
       pic(width: 640, height: 480) {
+      __typename
         url,
         width,
         height
@@ -40,6 +43,7 @@ const document = parse(`
 }
 
 fragment articleFields on Article {
+  __typename
   id,
   isPublished,
   title,
@@ -49,15 +53,7 @@ fragment articleFields on Article {
 }
 `);
 
-const { query }: any = compileQuery(schema, document, "", {
-  customSerializers: {
-    String,
-    ID: String,
-    Boolean,
-    Int: Number,
-    Float: Number
-  }
-});
+const { query }: any = compileQuery(schema, document, "");
 
 const suite = new Benchmark.Suite();
 

--- a/src/__benchmarks__/schema-variables.benchmark.ts
+++ b/src/__benchmarks__/schema-variables.benchmark.ts
@@ -18,15 +18,18 @@ const schema = getSchema();
 const document = parse(`
 query ($id: ID! = "1", $width: Int = 640, $height: Int = 480){
   feed {
+    __typename
     id,
     title
   },
   article(id: $id) {
     ...articleFields,
     author {
+      __typename
       id,
       name,
       pic(width: $width, height: $height) {
+      __typename
         url,
         width,
         height
@@ -40,6 +43,7 @@ query ($id: ID! = "1", $width: Int = 640, $height: Int = 480){
 }
 
 fragment articleFields on Article {
+  __typename
   id,
   isPublished,
   title,
@@ -57,15 +61,7 @@ const { query: compilerParserNoLeaf }: any = compileQuery(
     disableLeafSerialization: true
   }
 );
-const compilerParser: any = compileQuery(schema, document, "", {
-  customSerializers: {
-    String: String,
-    ID: String,
-    Boolean: Boolean,
-    Int: Number,
-    Float: Number
-  }
-});
+const compilerParser: any = compileQuery(schema, document, "");
 const vars = { id: "1" };
 
 const suite = new Benchmark.Suite();

--- a/src/__benchmarks__/schema.benchmark.ts
+++ b/src/__benchmarks__/schema.benchmark.ts
@@ -18,15 +18,18 @@ const schema = getSchema();
 const document = parse(`
 {
   feed {
+    __typename
     id,
     title
   },
   article(id: "1") {
     ...articleFields,
     author {
+      __typename
       id,
       name,
       pic(width: 640, height: 480) {
+      __typename
         url,
         width,
         height
@@ -40,6 +43,7 @@ const document = parse(`
 }
 
 fragment articleFields on Article {
+  __typename
   id,
   isPublished,
   title,
@@ -49,15 +53,7 @@ fragment articleFields on Article {
 }
 `);
 
-const { query }: any = compileQuery(schema, document, "", {
-  customSerializers: {
-    String,
-    ID: String,
-    Boolean,
-    Int: Number,
-    Float: Number
-  }
-});
+const { query }: any = compileQuery(schema, document, "");
 
 const suite = new Benchmark.Suite();
 

--- a/src/__tests__/resolve-info.test.ts
+++ b/src/__tests__/resolve-info.test.ts
@@ -74,6 +74,32 @@ describe("resolver info", () => {
       ).toThrow();
     });
 
+    test("enricher can overrule resolve info properties", () => {
+      const prepared = compileQuery(schema, parse(`query { foo { a } }`), "", {
+        resolverInfoEnricher: () => ({ schema: "hello" })
+      });
+      if (!isCompiledQuery(prepared)) {
+        throw prepared;
+      }
+      prepared.query(undefined, undefined, {});
+      expect(Object.keys(inf).sort()).toEqual(normalResolveInfoFields);
+      expect(inf.schema).toBe("hello");
+    });
+
+    test("enricher can add properties", () => {
+      const prepared = compileQuery(schema, parse(`query { foo { a } }`), "", {
+        resolverInfoEnricher: () => ({ fancyNewField: "hello" })
+      });
+      if (!isCompiledQuery(prepared)) {
+        throw prepared;
+      }
+      prepared.query(undefined, undefined, {});
+      expect(Object.keys(inf).sort()).toEqual(
+        normalResolveInfoFields.concat("fancyNewField").sort()
+      );
+      expect(inf.fancyNewField).toBe("hello");
+    });
+
     // The type system covers for a lot of these cases but
     // not everyone is using Typescript.
     describe("enricher return types", () => {

--- a/src/resolve-info.ts
+++ b/src/resolve-info.ts
@@ -1,3 +1,4 @@
+import genFn from "generate-function";
 import {
   doTypesOverlap,
   FieldNode,
@@ -18,7 +19,6 @@ import {
 } from "graphql";
 import memoize from "lodash.memoize";
 import mergeWith from "lodash.mergewith";
-import { ObjectPath } from "./ast";
 import { memoize2, memoize4 } from "./memoize";
 
 // TODO(boopathi): Use negated types to express
@@ -110,7 +110,8 @@ export function createResolveInfoThunk<T>(
       enrichedInfo = {};
     }
   }
-  let enrichedProperties = `return function getGraphQLResolveInfo(rootValue, variableValues, path) {
+  const gen = genFn();
+  gen(`return function getGraphQLResolveInfo(rootValue, variableValues, path) {
       return {
           fieldName,
           fieldNodes,
@@ -121,11 +122,11 @@ export function createResolveInfoThunk<T>(
           fragments,
           rootValue,
           operation,
-          variableValues,`;
+          variableValues,`);
   Object.keys(enrichedInfo).forEach(key => {
-    enrichedProperties += `${key}: enrichedInfo["${key}"],\n`;
+    gen(`${key}: enrichedInfo["${key}"],\n`);
   });
-  enrichedProperties += `};};`;
+  gen(`};};`);
   return new Function(
     "fieldName",
     "fieldNodes",
@@ -135,7 +136,7 @@ export function createResolveInfoThunk<T>(
     "fragments",
     "operation",
     "enrichedInfo",
-    enrichedProperties
+    gen.toString()
   ).call(
     null,
     fieldName,

--- a/src/resolve-info.ts
+++ b/src/resolve-info.ts
@@ -92,33 +92,61 @@ export function createResolveInfoThunk<T>(
     fieldName: string;
     fieldNodes: FieldNode[];
   },
-  enricher: (inp: ResolveInfoEnricherInput) => T = () => ({} as T)
+  enricher?: (inp: ResolveInfoEnricherInput) => T
 ) {
-  const enricherInput = {
+  let enrichedInfo = {};
+  if (typeof enricher === "function") {
+    enrichedInfo =
+      enricher({
+        fieldName,
+        fieldNodes,
+        returnType: fieldType,
+        parentType,
+        schema,
+        fragments,
+        operation
+      }) || {};
+    if (typeof enrichedInfo !== "object" || Array.isArray(enrichedInfo)) {
+      enrichedInfo = {};
+    }
+  }
+  let enrichedProperties = `return function getGraphQLResolveInfo(rootValue, variableValues, path) {
+      return {
+          fieldName,
+          fieldNodes,
+          returnType: fieldType,
+          parentType,
+          path,
+          schema,
+          fragments,
+          rootValue,
+          operation,
+          variableValues,`;
+  Object.keys(enrichedInfo).forEach(key => {
+    enrichedProperties += `${key}: enrichedInfo["${key}"],\n`;
+  });
+  enrichedProperties += `};};`;
+  return new Function(
+    "fieldName",
+    "fieldNodes",
+    "fieldType",
+    "parentType",
+    "schema",
+    "fragments",
+    "operation",
+    "enrichedInfo",
+    enrichedProperties
+  ).call(
+    null,
     fieldName,
     fieldNodes,
-    returnType: fieldType,
+    fieldType,
     parentType,
     schema,
     fragments,
-    operation
-  };
-
-  const enrichedInfo = {
-    ...enricherInput,
-    ...enricher(enricherInput)
-  };
-
-  return (
-    rootValue: any,
-    variableValues: any,
-    path: ObjectPath
-  ): GraphQLJitResolveInfo<T> => ({
-    rootValue,
-    variableValues,
-    path,
-    ...enrichedInfo
-  });
+    operation,
+    enrichedInfo
+  );
 }
 
 export function fieldExpansionEnricher(input: ResolveInfoEnricherInput) {


### PR DESCRIPTION
This was a regression when we added the enriching functionality.
There is nothing conceptually that forces this to be expensive so move this to compiled code.

Before: `graphql-jit x 52,908 ops/sec ±3.06% (74 runs sampled)`
After: `graphql-jit x 92,752 ops/sec ±1.91% (76 runs sampled)`

Related with #52 