### PR TITLE
benchmark with nested arrays

### DIFF
--- a/src/__benchmarks__/schema-nested-arrays.benchmark.ts
+++ b/src/__benchmarks__/schema-nested-arrays.benchmark.ts
@@ -1,0 +1,284 @@
+import Benchmark from "benchmark";
+import {
+  execute,
+  GraphQLBoolean,
+  GraphQLID,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  parse
+} from "graphql";
+import { compileQuery } from "../";
+
+const articlesCount = 25;
+const badgesCount = 25;
+const advertsCount = 25;
+
+const schema = getSchema();
+const document = parse(`
+{
+  feed {
+    __typename
+    id,
+    title
+  },
+  article(id: "1") {
+    ...articleFields,
+    author {
+      __typename
+      id,
+      name,
+      pic(width: 640, height: 480) {
+      __typename
+        url,
+        width,
+        height
+      },
+      articles {
+        ...articleFields,
+        keywords,
+        badges {
+          color, text
+        },
+        adverts {
+          text,
+          image {
+            url,
+            width,
+            height
+          }
+        }
+      }
+    }
+  }
+}
+
+fragment articleFields on Article {
+  __typename
+  id,
+  isPublished,
+  title,
+  body,
+  hidden,
+  notdefined
+}
+`);
+
+const { query }: any = compileQuery(schema, document, "");
+
+const suite = new Benchmark.Suite();
+
+suite
+  .add("graphql-js", {
+    defer: true,
+    fn(deferred: any) {
+      const p: any = execute(schema, document);
+      p.then(() => deferred.resolve());
+    }
+  })
+  .add("graphql-jit", {
+    defer: true,
+    fn(deferred: any) {
+      query(undefined, undefined, {}).then(() => deferred.resolve());
+    }
+  })
+  // add listeners
+  .on("cycle", (event: any) => {
+    // tslint:disable-next-line
+    console.log(String(event.target));
+  })
+  .on("complete", () => {
+    // tslint:disable-next-line
+    console.log("Fastest is " + suite.filter("fastest").map("name" as any));
+  })
+  .run();
+
+function getSchema() {
+  const BlogImage = new GraphQLObjectType({
+    name: "Image",
+    fields: {
+      url: {
+        type: GraphQLString,
+        resolve: image => Promise.resolve(image.url)
+      },
+      width: {
+        type: GraphQLInt,
+        resolve: image => Promise.resolve(image.width)
+      },
+      height: {
+        type: GraphQLInt,
+        resolve: image => Promise.resolve(image.height)
+      }
+    }
+  });
+
+  const articles = [];
+  const badges = [];
+  const adverts = [];
+
+  const BlogAuthor = new GraphQLObjectType({
+    name: "Author",
+    fields: () => ({
+      id: {
+        type: GraphQLString,
+        resolve: author => Promise.resolve(author.id)
+      },
+      name: {
+        type: GraphQLString,
+        resolve: author => Promise.resolve(author.name)
+      },
+      pic: {
+        args: { width: { type: GraphQLInt }, height: { type: GraphQLInt } },
+        type: BlogImage,
+        resolve: (obj, { width, height }) => obj.pic(width, height)
+      },
+      articles: {
+        type: new GraphQLList(BlogArticle),
+        resolve: _ => Promise.resolve(articles)
+      }
+    })
+  });
+
+  const BlogArticleBadge: GraphQLObjectType = new GraphQLObjectType({
+    name: "ArticleBadge",
+    fields: {
+      color: {
+        type: GraphQLString,
+        resolve: badge => Promise.resolve(badge && badge.color)
+      },
+      text: {
+        type: GraphQLString,
+        resolve: badge => Promise.resolve(badge && badge.text)
+      }
+    }
+  });
+
+  const BlogArticleAdvert: GraphQLObjectType = new GraphQLObjectType({
+    name: "ArticleAdvert",
+    fields: {
+      text: {
+        type: GraphQLString,
+        resolve: advert => Promise.resolve(advert && advert.text)
+      },
+      image: {
+        type: BlogImage,
+        resolve: advert => Promise.resolve(advert && advert.image)
+      }
+    }
+  });
+
+  const BlogArticle: GraphQLObjectType = new GraphQLObjectType({
+    name: "Article",
+    fields: {
+      id: {
+        type: new GraphQLNonNull(GraphQLID),
+        resolve: article => Promise.resolve(article.id)
+      },
+      isPublished: {
+        type: GraphQLBoolean,
+        resolve: article => Promise.resolve(article.isPublished)
+      },
+      author: { type: BlogAuthor },
+      title: {
+        type: GraphQLString,
+        resolve: article => Promise.resolve(article && article.title)
+      },
+      body: {
+        type: GraphQLString,
+        resolve: article => Promise.resolve(article.body)
+      },
+      keywords: {
+        type: new GraphQLList(GraphQLString),
+        resolve: article => Promise.resolve(article.keywords)
+      },
+      badges: {
+        type: new GraphQLList(BlogArticleBadge)
+      },
+      adverts: {
+        type: new GraphQLList(BlogArticleAdvert)
+      }
+    }
+  });
+
+  const BlogQuery = new GraphQLObjectType({
+    name: "Query",
+    fields: {
+      article: {
+        type: BlogArticle,
+        args: { id: { type: GraphQLID } },
+        resolve: (_, { id }) => article(id)
+      },
+      feed: {
+        type: new GraphQLList(BlogArticle),
+        resolve: () =>
+          Promise.resolve([
+            article(1),
+            article(2),
+            article(3),
+            article(4),
+            article(5),
+            article(6),
+            article(7),
+            article(8),
+            article(9),
+            article(10)
+          ])
+      }
+    }
+  });
+
+  for (let i = 0; i < badgesCount; i++) {
+    badges.push({
+      color: "color" + i,
+      text: "text" + i
+    });
+  }
+
+  for (let i = 0; i < advertsCount; i++) {
+    adverts.push({
+      text: "text" + i,
+      image: getPic(i, 100, 200)
+    });
+  }
+
+  const johnSmith = {
+    id: 123,
+    name: "John Smith",
+    pic: (width: number, height: number) => getPic(123, width, height),
+    recentArticle: null
+  };
+  johnSmith.recentArticle = article(1);
+
+  function article(id: number): any {
+    return {
+      id,
+      isPublished: true,
+      author: johnSmith,
+      title: "My Article " + id,
+      body: "This is a post",
+      hidden: "This data is not exposed in the schema",
+      keywords: ["foo", "bar", 1, true, null],
+      badges,
+      adverts
+    };
+  }
+
+  for (let i = 0; i < articlesCount; i++) {
+    articles.push(article(i));
+  }
+
+  function getPic(uid: number, width: number, height: number) {
+    return {
+      url: `cdn://${uid}`,
+      width: `${width}`,
+      height: `${height}`
+    };
+  }
+
+  return new GraphQLSchema({
+    query: BlogQuery
+  });
+}


### PR DESCRIPTION
Hi,
This is related to #52.

I wrote a little benchmark to illustrate how both `graphql-js` and `graphql-jit` behave when you introduce arrays to your schema and fill them with data.

```
src/__benchmarks__/schema-many-resolvers.benchmark.ts:
graphql-js x 11,092 ops/sec ±6.37% (73 runs sampled)
graphql-jit x 80,470 ops/sec ±2.44% (77 runs sampled)

src/__benchmarks__/schema-nested-arrays.benchmark.ts:
graphql-js x 97.86 ops/sec ±10.78% (79 runs sampled)
graphql-jit x 602 ops/sec ±4.60% (77 runs sampled)
```

Main difference between two benchmarks is that in the `nested-arrays` case we have 25 articles attached to the author and each article has 25 badges and 25 adverts.

Not sure if these benchmark results are the best we can do. After all we have to resolve each element in an array so it degrades proportionally to an array length.