### PR TITLE
Reuse arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ Compiles the `document` AST, using an optional operationName and compiler option
 
   - `disableLeafSerialization` {boolean, default: false} - disables leaf node serializers. The serializers validate the content of the field
     so this option should only be set to true if there are strong assurances that the values are valid.
+  - `reuseArrayMemory` {boolean, default: false} - reuses the array that are returned from the resolver instead of allocating new ones.
+  This should only be enabled if the original array will no longer be required.
   - `customSerializers` {Object as Map, default: {}} - Replace serializer functions for specific types. Can be used as a safer alternative
-    for overly expensive
+    for overly expensive serializer functions.
   - `customJSONSerializer` {boolean, default: false} - Whether to produce also a JSON serializer function using `fast-json-stringify`,
     otherwise the stringify function is just `JSON.stringify`
 

--- a/src/__benchmarks__/schema-nested-arrays.benchmark.ts
+++ b/src/__benchmarks__/schema-nested-arrays.benchmark.ts
@@ -67,7 +67,12 @@ fragment articleFields on Article {
 }
 `);
 
-const { query }: any = compileQuery(schema, document, "");
+const { query: memory }: any = compileQuery(schema, document, "", {
+  reuseArrays: true
+});
+const { query }: any = compileQuery(schema, document, "", {
+  reuseArrays: false
+});
 
 const suite = new Benchmark.Suite();
 
@@ -83,6 +88,12 @@ suite
     defer: true,
     fn(deferred: any) {
       query(undefined, undefined, {}).then(() => deferred.resolve());
+    }
+  })
+  .add("graphql-jit - reuse arrays", {
+    defer: true,
+    fn(deferred: any) {
+      memory(undefined, undefined, {}).then(() => deferred.resolve());
     }
   })
   // add listeners

--- a/src/__benchmarks__/schema-nested-arrays.benchmark.ts
+++ b/src/__benchmarks__/schema-nested-arrays.benchmark.ts
@@ -68,10 +68,10 @@ fragment articleFields on Article {
 `);
 
 const { query: memory }: any = compileQuery(schema, document, "", {
-  reuseArrays: true
+  reuseArrayMemory: true
 });
 const { query }: any = compileQuery(schema, document, "", {
-  reuseArrays: false
+  reuseArrayMemory: false
 });
 
 const suite = new Benchmark.Suite();
@@ -126,9 +126,9 @@ function getSchema() {
     }
   });
 
-  const articles = [];
-  const badges = [];
-  const adverts = [];
+  const articles: any[] = [];
+  const badges: any[] = [];
+  const adverts: any[] = [];
 
   const BlogAuthor = new GraphQLObjectType({
     name: "Author",

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -67,7 +67,7 @@ export interface CompilerOptions {
 
   // If set it reuses the memory of the arrays being transformed
   // saving the allocation costs of an intermediate array.
-  reuseArrays: boolean;
+  reuseArrayMemory: boolean;
 
   // Map of serializers to override
   // the key should be the name passed to the Scalar or Enum type
@@ -163,7 +163,7 @@ export function compileQuery(
       disablingCapturingStackErrors: false,
       customJSONSerializer: false,
       disableLeafSerialization: false,
-      reuseArrays: false,
+      reuseArrayMemory: false,
       customSerializers: {},
       ...partialOptions
     };
@@ -857,7 +857,7 @@ function compileListType(
   )}), null)`;
   return `(typeof ${name} === "string" || typeof ${name}[Symbol.iterator] !== "function") ?  ${errorCase} :
   __safeMap(${
-    context.options.reuseArrays
+    context.options.reuseArrayMemory
   }, ${name}, (__safeMapNode, idx${newDepth}) => {
      ${generateUniqueDeclarations(listContext)}
      const __child = ${dataBody};


### PR DESCRIPTION
The intermediate array allocated to generate the final shape is pointless if the users do not plan on using the previous one.

This allows saving pointless array allocations.
It is disabled by default since it is an dangerous option for the cases where the user does require the original array to be kept.

Related with #52.
```
graphql-js x 111 ops/sec ±2.32% (72 runs sampled)
graphql-jit x 516 ops/sec ±4.42% (69 runs sampled)
graphql-jit - reuse arrays x 1,099 ops/sec ±2.52% (73 runs sampled)
```