### PR TITLE
Remove functionBody unless requested.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-jit",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "GraphQL JIT Compiler to JS",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/__tests__/execution.test.ts
+++ b/src/__tests__/execution.test.ts
@@ -85,6 +85,30 @@ describe("Execute: Handles basic execution tasks", () => {
     ).toThrow("resolverInfoEnricher must be a function");
   });
 
+  test("return the generated function if debug is passed in the options", async () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: "Type",
+        fields: {
+          a: { type: GraphQLString }
+        }
+      })
+    });
+
+    let compiled: any = compileQuery(schema, parse("{ field }"), "", {
+      debug: true
+    } as any);
+
+    expect(
+      compiled.__DO_NOT_USE_THIS_OR_YOU_WILL_BE_FIRED_compilation
+    ).toBeDefined();
+
+    compiled = compileQuery(schema, parse("{ field }"));
+    expect(
+      compiled.__DO_NOT_USE_THIS_OR_YOU_WILL_BE_FIRED_compilation
+    ).not.toBeDefined();
+  });
+
   test("throws if no schema is provided", async () => {
     expect(() =>
       executeArgs({

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -26,7 +26,6 @@ import {
   isObjectType,
   isSpecifiedScalarType,
   Kind,
-  print,
   TypeNameMetaFieldDef
 } from "graphql";
 import {
@@ -169,7 +168,7 @@ export interface CompiledQuery {
 }
 
 interface InternalCompiledQuery extends CompiledQuery {
-  __DO_NOT_USE_THIS_OR_YOU_WILL_BE_FIRED_compilation: string;
+  __DO_NOT_USE_THIS_OR_YOU_WILL_BE_FIRED_compilation?: string;
 }
 
 /**
@@ -241,11 +240,11 @@ export function compileQuery(
           ? context.operation.name.value
           : undefined
       ),
-      stringify,
-      // result of the compilation useful for debugging issues
-      // and visualization tools like try-jit.
-      __DO_NOT_USE_THIS_OR_YOU_WILL_BE_FIRED_compilation: functionBody
+      stringify
     };
+    if ((options as any).debug) {
+      compiledQuery.__DO_NOT_USE_THIS_OR_YOU_WILL_BE_FIRED_compilation = functionBody;
+    }
     return compiledQuery;
   } catch (err) {
     return {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -243,6 +243,8 @@ export function compileQuery(
       stringify
     };
     if ((options as any).debug) {
+      // result of the compilation useful for debugging issues
+      // and visualization tools like try-jit.
       compiledQuery.__DO_NOT_USE_THIS_OR_YOU_WILL_BE_FIRED_compilation = functionBody;
     }
     return compiledQuery;


### PR DESCRIPTION
With large amount of persisted queries, it has a noticeable memory cost.