### PR TITLE
feat: add support for skip and include directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/lodash.memoize": "^4.1.6",
     "@types/lodash.merge": "^4.6.6",
     "@types/lodash.mergewith": "^4.6.6",
+    "@types/lodash.zip": "^4.2.6",
     "@types/node": "^10.17.26",
     "benchmark": "^2.1.4",
     "codecov": "^3.3.0",
@@ -80,7 +81,8 @@
     "json-schema": "^0.2.3",
     "lodash.memoize": "^4.1.2",
     "lodash.merge": "4.6.2",
-    "lodash.mergewith": "4.6.2"
+    "lodash.mergewith": "4.6.2",
+    "lodash.zip": "^4.2.0"
   },
   "lint-staged": {
     "linters": {

--- a/src/__tests__/lodash.zip.d.ts
+++ b/src/__tests__/lodash.zip.d.ts
@@ -1,0 +1,7 @@
+import { zip } from "lodash";
+
+declare module "lodash" {
+  interface LodashStatic {
+    zip<T>(...arrays: Array<Array<T>>): Array<Array<T>>;
+  }
+}

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -52,7 +52,7 @@ export function collectFields(
   selectionSet: SelectionSetNode,
   fields: { [key: string]: JitFieldNode[] },
   // The directives on fragments along the field's path in query
-  fragmentDirectives?: Array<Array<DirectiveNode>>
+  fragmentDirectives?: DirectiveNode[][]
 ): { [key: string]: JitFieldNode[] } {
   for (const selection of selectionSet.selections) {
     switch (selection.kind) {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -28,11 +28,12 @@ import {
   Kind,
   TypeNameMetaFieldDef
 } from "graphql";
+import { ExecutionContext as GraphQLContext } from "graphql/execution/execute";
 import {
-  collectFields,
-  ExecutionContext as GraphQLContext
-} from "graphql/execution/execute";
-import { FieldNode, OperationDefinitionNode } from "graphql/language/ast";
+  FieldNode,
+  OperationDefinitionNode,
+  DirectiveNode
+} from "graphql/language/ast";
 import Maybe from "graphql/tsutils/Maybe";
 import { GraphQLTypeResolver } from "graphql/type/definition";
 import {
@@ -43,7 +44,9 @@ import {
   flattenPath,
   getArgumentDefs,
   ObjectPath,
-  resolveFieldDef
+  resolveFieldDef,
+  JitFieldNode,
+  collectFields
 } from "./ast";
 import { GraphQLError as GraphqlJitError } from "./error";
 import createInspect from "./inspect";
@@ -78,6 +81,8 @@ export interface CompilerOptions {
 
   resolverInfoEnricher?: (inp: ResolveInfoEnricherInput) => object;
 }
+
+type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 
 /**
  * The context used during compilation.
@@ -377,7 +382,6 @@ function compileOperation(context: CompilationContext) {
     context,
     type,
     context.operation.selectionSet,
-    Object.create(null),
     Object.create(null)
   );
   const topLevel = compileObjectType(
@@ -386,7 +390,7 @@ function compileOperation(context: CompilationContext) {
     [],
     [GLOBAL_ROOT_NAME],
     [GLOBAL_DATA_NAME],
-    undefined,
+    addPath(undefined, ""),
     GLOBAL_ERRORS_NAME,
     fieldMap,
     true
@@ -535,7 +539,10 @@ function compileDeferredField(
       if (${isPromiseInliner("__value")}) {
       ${promiseStarted()}
        __value.then(result => {
-        ${resolverHandler}(${GLOBAL_EXECUTION_CONTEXT}, ${resultParentPath}, result, ${parentIndexes});
+        // if the field was skipped, do not call resolver
+        if (Object.prototype.hasOwnProperty.call(${resultParentPath}, "${fieldName}")) {
+          ${resolverHandler}(${GLOBAL_EXECUTION_CONTEXT}, ${resultParentPath}, result, ${parentIndexes});
+        }
         ${promiseDone()}
        }, err => {
         if (err) {
@@ -545,7 +552,8 @@ function compileDeferredField(
         }
         ${promiseDone()}
        });
-      } else {
+      } else if (Object.prototype.hasOwnProperty.call(${resultParentPath}, "${fieldName}")) {
+        // if the field was skipped, do not call resolver
         ${resolverHandler}(${GLOBAL_EXECUTION_CONTEXT}, ${resultParentPath}, __value, ${parentIndexes});
       }
     }`;
@@ -749,7 +757,7 @@ function compileObjectType(
   destinationPaths: string[],
   responsePath: ObjectPath | undefined,
   errorDestination: string,
-  fieldMap: { [key: string]: FieldNode[] },
+  fieldMap: { [key: string]: JitFieldNode[] },
   alwaysDefer: boolean
 ): string {
   let body = "(";
@@ -780,50 +788,39 @@ function compileObjectType(
       continue;
     }
 
-    let compiledSkipDirective;
-    let compiledIncludeDirective;
-
-    if (responsePath != null) {
-      compiledSkipDirective = compileQueryDirective(
-        context,
-        "skip",
-        `skip${name}`,
-        fieldNodes[0],
-        type,
-        responsePath
-      );
-      compiledIncludeDirective = compileQueryDirective(
-        context,
-        "include",
-        `include${name}`,
-        fieldNodes[0],
-        type,
-        responsePath
-      );
-    }
-
     const isSkippedName = getIsSkippedName(name);
 
     iifeBody += `
       var ${isSkippedName} = false;
     `;
-    if (compiledIncludeDirective != null) {
-      iifeBody += `
-        ${compiledIncludeDirective.body}
-        if (${compiledIncludeDirective.argsName}.if === true) {
-          ${isSkippedName} = false
-        }
-      `;
-    }
 
-    // "skip" overrides "include"
-    if (compiledSkipDirective != null) {
-      iifeBody += `
-        ${compiledSkipDirective.body}
-        if (${compiledSkipDirective.argsName}.if === true) {
-          ${isSkippedName} = true
+    if (responsePath != null) {
+      for (const fieldNode of fieldNodes) {
+        if (fieldNode.fragmentDirectives != null) {
+          for (const directives of fieldNode.fragmentDirectives) {
+            iifeBody += compileSkipIncludeDirectives(
+              context,
+              directives,
+              name,
+              isSkippedName,
+              fieldNode,
+              type,
+              responsePath
+            );
+          }
         }
-      `;
+        if (fieldNode.directives != null) {
+          iifeBody += compileSkipIncludeDirectives(
+            context,
+            fieldNode.directives as Writeable<DirectiveNode[]>,
+            name,
+            isSkippedName,
+            fieldNode,
+            type,
+            responsePath
+          );
+        }
+      }
     }
 
     // Name is the field name or an alias supplied by the user
@@ -1222,31 +1219,85 @@ function objectPath(topLevel: string, path?: ObjectPath) {
   return objectPath;
 }
 
+function compileSkipIncludeDirectives(
+  context: CompilationContext,
+  directiveNodes: DirectiveNode[],
+  fieldName: string,
+  isSkippedName: string,
+  fieldNode: FieldNode,
+  returnType: GraphQLOutputType,
+  responsePath: ObjectPath
+): string {
+  let body = "";
+
+  const compiledDirectives: {
+    name: string;
+    argsName: string;
+    body: string;
+  }[] = [];
+
+  for (const directive of directiveNodes) {
+    if (directive.name.value === "skip" || directive.name.value === "include") {
+      const compiledDirective = compileQueryDirective(
+        context,
+        directive,
+        `${directive.name.value}${fieldName}`,
+        fieldNode,
+        returnType,
+        responsePath
+      );
+      if (compiledDirective) {
+        compiledDirectives.push(compiledDirective);
+      }
+    }
+  }
+
+  /**
+   * Skip has higher priority than include.
+   * So we push it to the end
+   */
+  const sortedDirectives = compiledDirectives.sort((a, b) => {
+    if (a.name === b.name) return 0;
+    if (a.name === "skip") return 1;
+    if (b.name === "include") return -1;
+    return 0;
+  });
+
+  for (const compiledDirective of sortedDirectives) {
+    body += `${compiledDirective.body}`;
+
+    if (compiledDirective.name === "skip") {
+      body += `
+        if (${compiledDirective.argsName}.if === true) {
+          ${isSkippedName} = true;
+        }
+      `;
+    } else if (compiledDirective.name === "include") {
+      body += `
+        if (${compiledDirective.argsName}.if === false) {
+          ${isSkippedName} = true;
+        }
+      `;
+    }
+  }
+
+  return body;
+}
+
 function compileQueryDirective(
   context: CompilationContext,
-  directiveName: string,
+  directiveNode: DirectiveNode,
   prefix: string,
   fieldNode: FieldNode,
   returnType: GraphQLOutputType,
   path: ObjectPath
-): null | { argsName: string; body: string } {
-  if (fieldNode.directives == null) {
-    return null;
-  }
-
-  const directive = context.schema.getDirective(directiveName);
+): null | { argsName: string; body: string; name: string } {
+  const directive = context.schema.getDirective(directiveNode.name.value);
   if (directive == null) {
     throw new GraphQLError(
-      `Directive @${directiveName} is not defined`,
+      `Directive @${directiveNode.name.value} is not defined`,
       fieldNode
     );
-  }
-
-  const directiveNode = fieldNode.directives.find(
-    directive => directive.name.value === directiveName
-  );
-  if (directiveNode == null) {
-    return null;
   }
 
   const argsName = getArgumentsName(prefix);
@@ -1259,7 +1310,7 @@ function compileQueryDirective(
     path
   );
 
-  return { argsName, body };
+  return { argsName, body, name: directiveNode.name.value };
 }
 
 /**

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -119,6 +119,11 @@ const GRAPHQL_ERROR = "__context.GraphQLError";
 const GLOBAL_RESOLVE = "__context.resolve";
 const GLOBAL_PARENT_NAME = "__parent";
 const LOCAL_JS_FIELD_NAME_PREFIX = "__field";
+const GLOBAL_MAKE_OBJECT_NAME = "__makeObject";
+
+const LOCAL_OBJECT_VAR_NAME = "__object";
+const LOCAL_IS_SKIPPED_NAME = "__isSkipped";
+const LOCAL_SOURCE_NAME = "__source";
 
 interface ExecutionContext {
   promiseCounter: number;
@@ -235,7 +240,6 @@ export function compileQuery(
     const compiledQuery: InternalCompiledQuery = {
       query: createBoundQuery(
         context,
-        document,
         new Function("return " + functionBody)(),
         getVariables,
         context.operation.name != null
@@ -264,10 +268,8 @@ export function isCompiledQuery<
   return "query" in query && typeof query.query === "function";
 }
 
-// Exported only for an error test
-export function createBoundQuery(
+function createBoundQuery(
   compilationContext: CompilationContext,
-  document: DocumentNode,
   func: (context: ExecutionContext) => Promise<any> | undefined,
   getVariableValues: (inputs: { [key: string]: any }) => CoercedVariableValues,
   operationName?: string
@@ -520,6 +522,7 @@ function compileDeferredField(
     fieldType,
     responsePath
   );
+
   const body = `
     ${compiledArgs}
     if (${validArgs} === true) {
@@ -546,14 +549,15 @@ function compileDeferredField(
         ${resolverHandler}(${GLOBAL_EXECUTION_CONTEXT}, ${resultParentPath}, __value, ${parentIndexes});
       }
     }`;
+
   context.hoistedFunctions.push(`
-       function ${resolverHandler}(${GLOBAL_EXECUTION_CONTEXT}, ${GLOBAL_PARENT_NAME}, ${jsFieldName}, ${parentIndexes}) {
-          ${generateUniqueDeclarations(subContext)}
-          ${GLOBAL_PARENT_NAME}.${name} = ${nodeBody};
-          ${compileDeferredFields(subContext)}
-          ${appendix ? appendix : ""}
-        }
-      `);
+    function ${resolverHandler}(${GLOBAL_EXECUTION_CONTEXT}, ${GLOBAL_PARENT_NAME}, ${jsFieldName}, ${parentIndexes}) {
+      ${generateUniqueDeclarations(subContext)}
+      ${GLOBAL_PARENT_NAME}.${name} = ${nodeBody};
+      ${compileDeferredFields(subContext)}
+      ${appendix ? appendix : ""}
+    }
+  `);
   return body;
 }
 
@@ -764,7 +768,9 @@ function compileObjectType(
       }" but got: $\{${GLOBAL_INSPECT_NAME}(${originPaths.join(".")})}.\``
     )}), null) :`;
   }
-  body += "{";
+
+  let iifeBody = "";
+
   for (const name of Object.keys(fieldMap)) {
     const fieldNodes = fieldMap[name];
     const field = resolveFieldDef(context, type, fieldNodes);
@@ -773,21 +779,81 @@ function compileObjectType(
       // but the error is swallowed for compatibility reasons.
       continue;
     }
+
+    let compiledSkipDirective;
+    let compiledIncludeDirective;
+
+    if (responsePath != null) {
+      compiledSkipDirective = compileQueryDirective(
+        context,
+        "skip",
+        `skip${name}`,
+        fieldNodes[0],
+        type,
+        responsePath
+      );
+      compiledIncludeDirective = compileQueryDirective(
+        context,
+        "include",
+        `include${name}`,
+        fieldNodes[0],
+        type,
+        responsePath
+      );
+    }
+
+    const isSkippedName = getIsSkippedName(name);
+
+    iifeBody += `
+      var ${isSkippedName} = false;
+    `;
+    if (compiledIncludeDirective != null) {
+      iifeBody += `
+        ${compiledIncludeDirective.body}
+        if (${compiledIncludeDirective.argsName}.if === true) {
+          ${isSkippedName} = false
+        }
+      `;
+    }
+
+    // "skip" overrides "include"
+    if (compiledSkipDirective != null) {
+      iifeBody += `
+        ${compiledSkipDirective.body}
+        if (${compiledSkipDirective.argsName}.if === true) {
+          ${isSkippedName} = true
+        }
+      `;
+    }
+
     // Name is the field name or an alias supplied by the user
-    body += `${name}: `;
+    iifeBody += `
+      if (!${isSkippedName}) {
+        ${LOCAL_OBJECT_VAR_NAME}.${name} = `;
 
     // Inline __typename
     // No need to call a resolver for typename
     if (field === TypeNameMetaFieldDef) {
-      body += `"${type.name}",`;
+      iifeBody += `"${type.name}"; }`;
       continue;
     }
 
     let resolver = field.resolve;
-    if (!resolver && alwaysDefer) {
-      const fieldName = field.name;
-      resolver = parent => parent && parent[fieldName];
+
+    if (resolver == null) {
+      const shouldDefer =
+        alwaysDefer ||
+        fieldNodes.some(
+          fieldNode =>
+            fieldNode.directives != null && fieldNode.directives.length > 0
+        );
+
+      if (shouldDefer) {
+        const fieldName = field.name;
+        resolver = parent => parent && parent[fieldName];
+      }
     }
+
     if (resolver) {
       context.deferred.push({
         name,
@@ -802,10 +868,10 @@ function compileObjectType(
         args: getArgumentDefs(field, fieldNodes[0])
       });
       context.resolvers[getResolverName(type.name, field.name)] = resolver;
-      body += `(${SAFETY_CHECK_PREFIX}${context.deferred.length -
+      iifeBody += `(${SAFETY_CHECK_PREFIX}${context.deferred.length -
         1} = true, null)`;
     } else {
-      body += compileType(
+      iifeBody += compileType(
         context,
         type,
         field.type,
@@ -815,9 +881,18 @@ function compileObjectType(
         addPath(responsePath, name)
       );
     }
-    body += ",";
+    iifeBody += "}";
   }
-  body += "})";
+
+  body += `
+    (() => {
+      const ${LOCAL_OBJECT_VAR_NAME} = {};
+      ${iifeBody}
+      return ${LOCAL_OBJECT_VAR_NAME};
+    })()`;
+
+  body += ")";
+
   return body;
 }
 
@@ -1145,6 +1220,46 @@ function objectPath(topLevel: string, path?: ObjectPath) {
     }
   }
   return objectPath;
+}
+
+function compileQueryDirective(
+  context: CompilationContext,
+  directiveName: string,
+  prefix: string,
+  fieldNode: FieldNode,
+  returnType: GraphQLOutputType,
+  path: ObjectPath
+): null | { argsName: string; body: string } {
+  if (fieldNode.directives == null) {
+    return null;
+  }
+
+  const directive = context.schema.getDirective(directiveName);
+  if (directive == null) {
+    throw new GraphQLError(
+      `Directive @${directiveName} is not defined`,
+      fieldNode
+    );
+  }
+
+  const directiveNode = fieldNode.directives.find(
+    directive => directive.name.value === directiveName
+  );
+  if (directiveNode == null) {
+    return null;
+  }
+
+  const argsName = getArgumentsName(prefix);
+  const body = compileArguments(
+    context,
+    getArgumentDefs(directive, directiveNode),
+    argsName,
+    getValidArgumentsVarName(prefix),
+    returnType,
+    path
+  );
+
+  return { argsName, body };
 }
 
 /**
@@ -1511,6 +1626,10 @@ function getTypeResolverName(name: string) {
 
 function getSerializerName(name: string) {
   return name + "Serializer";
+}
+
+function getIsSkippedName(fieldName: string): string {
+  return `${LOCAL_IS_SKIPPED_NAME}${fieldName}`;
 }
 
 function promiseStarted() {

--- a/src/non-null.ts
+++ b/src/non-null.ts
@@ -136,7 +136,6 @@ function parseQueryNullables(exeContext: ExecutionContext): QueryMetadata {
     exeContext,
     type,
     exeContext.operation.selectionSet,
-    Object.create(null),
     Object.create(null)
   );
   const properties = Object.create(null);

--- a/yarn.lock
+++ b/yarn.lock
@@ -442,6 +442,13 @@
   dependencies:
     "@types/lodash" "*"
 
+"@types/lodash.zip@^4.2.6":
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.zip/-/lodash.zip-4.2.6.tgz#c30b441700a1707761aa36282de12bc80382dc0b"
+  integrity sha512-mKAcnkyFaihVR1oK83ZBQqSSQ1hpAY+uD5QaDkf//xtvr4NlNwqJEDg/oQoqLJg5YdSEwVWlQq0Aq4oLvD3zuw==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash@*":
   version "4.14.117"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.117.tgz#695a7f514182771a1e0f4345d189052ee33c8778"
@@ -3016,6 +3023,11 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
+lodash.zip@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
+  integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
 lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@~4.17.4:
   version "4.17.11"


### PR DESCRIPTION
+ fix #68 

This is a work in progress that adds support for skip and include directives for fields.

TODO:

- [ ] Support for fragments and inline fragments

Changes in generated code:

Compilation of object types now generate an IIFE (immediately invoked function expression) -

Previously -

```js
(
  {
    a: value,
    b: value
  }
)
```

Now -

```js
(() => {
  var object = {};
  // ...
  if (!isSkippeda) {
    object.a = value;
  }
  return object;
})()
```