### PR TITLE
added sample integration between graphql-jit and apollo

### DIFF
--- a/examples/blog-apollo-server/README.md
+++ b/examples/blog-apollo-server/README.md
@@ -1,0 +1,28 @@
+# Blog-apollo-server
+
+An example blog schema using GraphQL-Jit as custom executor for [Apollo Server](https://github.com/apollographql/apollo-server).
+
+## Running
+
+From the current directory.
+
+```sh
+yarn install
+ts-node src/server
+```
+
+## Executing Query
+
+Go to `http://localhost:3000/graphql` to run queries.
+
+Sample query:
+```
+query {
+  post(id: "post:1") {
+    title
+    author {
+      name
+    }
+  }
+}
+```

--- a/examples/blog-apollo-server/package.json
+++ b/examples/blog-apollo-server/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "blog-apollo-server",
+  "version": "0.1.0",
+  "dependencies": {
+    "apollo-server": "^2.9.16",
+    "graphql-jit": "^0.4.2",
+    "tiny-lru": "^7.0.2"
+  }
+}

--- a/examples/blog-apollo-server/package.json
+++ b/examples/blog-apollo-server/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "dependencies": {
     "apollo-server": "^2.9.16",
-    "graphql-jit": "^0.4.2",
     "tiny-lru": "^7.0.2"
   }
 }

--- a/examples/blog-apollo-server/schema.gql
+++ b/examples/blog-apollo-server/schema.gql
@@ -1,0 +1,25 @@
+type Query {
+  post(id: ID!): Post!
+  user(id: ID!): User!
+
+  node(id: ID!): Node!
+
+  posts: [Post!]
+  users: [User!]
+}
+
+interface Node {
+  id: ID!
+}
+
+type Post implements Node {
+  id: ID!
+  title: String!
+  author: User!
+}
+
+type User implements Node {
+  id: ID!
+  name: String!
+  posts: [Post!]
+}

--- a/examples/blog-apollo-server/src/executor.ts
+++ b/examples/blog-apollo-server/src/executor.ts
@@ -1,0 +1,33 @@
+import { GraphQLExecutor } from "apollo-server-core";
+import { GraphQLSchema } from "graphql";
+import {
+  CompiledQuery,
+  compileQuery,
+  CompilerOptions,
+  isCompiledQuery
+} from "graphql-jit";
+import LRU from "tiny-lru";
+
+export const executor = (
+  schema: GraphQLSchema,
+  cacheSize = 1024,
+  compilerOpts: Partial<CompilerOptions> = {}
+): GraphQLExecutor => {
+  const cache = LRU<CompiledQuery>(cacheSize);
+  return async ({ context, document, operationName, request, queryHash }) => {
+    const prefix = operationName || "NotParametrized";
+    const cacheKey = `${prefix}-${queryHash}`;
+    let compiledQuery = cache.get(cacheKey);
+    if (!compiledQuery) {
+      const compilationResult = compileQuery(schema, document, operationName || undefined, compilerOpts);
+      if (isCompiledQuery(compilationResult)) {
+        compiledQuery = compilationResult;
+        cache.set(cacheKey, compiledQuery);
+      } else {
+        // ...is ExecutionResult
+        return compilationResult;
+      }
+    }
+    return compiledQuery.query(undefined, context, request.variables || {});
+  };
+};

--- a/examples/blog-apollo-server/src/executor.ts
+++ b/examples/blog-apollo-server/src/executor.ts
@@ -1,12 +1,12 @@
 import { GraphQLExecutor } from "apollo-server-core";
 import { GraphQLSchema } from "graphql";
+import LRU from "tiny-lru";
 import {
   CompiledQuery,
   compileQuery,
   CompilerOptions,
   isCompiledQuery
-} from "graphql-jit";
-import LRU from "tiny-lru";
+} from "../../../";
 
 export const executor = (
   schema: GraphQLSchema,

--- a/examples/blog-apollo-server/src/resolvers.ts
+++ b/examples/blog-apollo-server/src/resolvers.ts
@@ -1,0 +1,94 @@
+const posts = [
+  {
+    id: "post:1",
+    title: "Introduction to GraphQL!",
+    author: {
+      id: "user:1"
+    }
+  },
+  {
+    id: "post:2",
+    title: "GraphQL-Jit a fast engine for GraphQL",
+    author: {
+      id: "user:2"
+    }
+  }
+];
+
+const users = [
+  {
+    id: "user:1",
+    name: "Boopathi",
+    posts: [
+      {
+        id: "post:1"
+      }
+    ]
+  },
+  {
+    id: "user:2",
+    name: "Rui",
+    posts: [
+      {
+        id: "post:2"
+      }
+    ]
+  }
+];
+
+function getPost(id: string) {
+  const post = posts.find(post => post.id === id);
+  if (post == null) {
+    throw new Error(`Post "${id} not found"`);
+  }
+  return post;
+}
+
+function getUser(id: string) {
+  const user = users.find(user => user.id === id);
+  if (user == null) {
+    throw new Error(`User "${id}" not found`);
+  }
+  return user;
+}
+
+export default {
+  Query: {
+    post(_: any, { id }: { id: string }) {
+      return getPost(id);
+    },
+    user(_: any, { id }: { id: string }) {
+      return getUser(id);
+    },
+    node(_: any, { id }: { id: string }) {
+      switch (id.split(":")[0]) {
+        case "post":
+          return { __typename: "Post", ...getPost(id) };
+        case "user":
+          return { __typename: "User", ...getUser(id) };
+      }
+      throw new Error("Invalid id");
+    },
+    posts() {
+      return posts;
+    },
+    users() {
+      return users;
+    }
+  },
+  Node: {
+    __resolveType({ __typename }: { __typename: string }) {
+      return __typename;
+    }
+  },
+  Post: {
+    author({ author }: { author: { id: string } }) {
+      return getUser(author.id);
+    }
+  },
+  User: {
+    posts({ posts }: { posts: { id: string }[] }) {
+      return posts.map(({ id }) => getPost(id));
+    }
+  }
+};

--- a/examples/blog-apollo-server/src/server.ts
+++ b/examples/blog-apollo-server/src/server.ts
@@ -1,8 +1,8 @@
 import { ApolloServer, makeExecutableSchema } from "apollo-server";
 import { readFileSync } from "fs";
 import path from "path";
-import resolvers from "../../blog/src/resolvers";
 import { executor } from "./executor";
+import resolvers from "./resolvers";
 
 const schema = makeExecutableSchema({
   typeDefs: readFileSync(path.join(__dirname, "../schema.gql"), "utf-8"),

--- a/examples/blog-apollo-server/src/server.ts
+++ b/examples/blog-apollo-server/src/server.ts
@@ -1,0 +1,18 @@
+import { ApolloServer, makeExecutableSchema } from "apollo-server";
+import { readFileSync } from "fs";
+import path from "path";
+import resolvers from "../../blog/src/resolvers";
+import { executor } from "./executor";
+
+const schema = makeExecutableSchema({
+  typeDefs: readFileSync(path.join(__dirname, "../schema.gql"), "utf-8"),
+  resolvers
+});
+const apollo = new ApolloServer({
+  schema,
+  executor: executor(schema)
+});
+
+apollo.listen({ port: 3000 }).then(() => {
+  console.log("Go to http://localhost:3000/graphql to run queries!");
+});

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/node": "^10.11.7",
     "benchmark": "^2.1.4",
     "codecov": "^3.3.0",
-    "graphql": "^14.2.1",
+    "graphql": "^14.5.3",
     "graphql-tools": "^4.0.4",
     "jest": "^24.7.1",
     "lint-staged": "^8.1.5",

--- a/src/__tests__/__snapshots__/schema.test.ts.snap
+++ b/src/__tests__/__snapshots__/schema.test.ts.snap
@@ -334,7 +334,7 @@ Object {
           "possibleTypes": null,
         },
         Object {
-          "description": "The \`Int\` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+          "description": "The \`Int\` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
           "enumValues": null,
           "fields": null,
           "inputFields": null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1796,10 +1796,10 @@ graphql-tools@^4.0.4:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-graphql@^14.2.1:
-  version "14.2.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.2.1.tgz#779529bf9a01e7207b977a54c20670b48ca6e95c"
-  integrity sha512-2PL1UbvKeSjy/lUeJqHk+eR9CvuErXoCNwJI4jm3oNFEeY+9ELqHNKO1ZuSxAkasPkpWbmT/iMRMFxd3cEL3tQ==
+graphql@^14.5.3:
+  version "14.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.6.0.tgz#57822297111e874ea12f5cd4419616930cd83e49"
+  integrity sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==
   dependencies:
     iterall "^1.2.2"
 


### PR DESCRIPTION
Related to: https://github.com/zalando-incubator/graphql-jit/issues/67

This PR contains sample integration between graphql-jit and Apollo Server. It can be used as a starting point to build more robust `apollo-server-graphql-jit` component in the future. What you probably want is to add metrics and logs for instance.

For legal reasons I can't contribute entire module that I was running on production (at least not yet, it has to pass lengthy security clearance to be open sourced). 