### PR TITLE
README: Update benchmark command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ code which yields much better performance.
 #### Benchmarks
 
 ```bash
-$ ts-node -T ./src/__benchmarks__/benchmarks.ts skip-json
+$ NODE_ENV=production ts-node -T ./src/__benchmarks__/benchmarks.ts skip-json
 Starting introspection
 graphql-js x 1,155 ops/sec ±1.55% (215 runs sampled)
 graphql-jit x 5,961 ops/sec ±5.34% (216 runs sampled)


### PR DESCRIPTION
Without `NODE_ENV=production` `graphql-js` uses dev version of `instanceOf`:
https://github.com/graphql/graphql-js/blob/master/src/jsutils/instanceOf.js