### PR TITLE
Make fast-json-stringify optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Compiles the `document` AST, using an optional operationName and compiler option
     so this option should only be set to true if there are strong assurances that the values are valid.
   - `customSerializers` {Object as Map, default: {}} - Replace serializer functions for specific types. Can be used as a safer alternative
     for overly expensive serializers
-  - `customJSONSerializer` {boolean, default: false} - Whether to produce also a JSON serializer function using `fast-json-stringify`. The default stringifier function is `JSON.stringify`
+  - `fastJson` {`require(fast-json-stringify)`, default: undefined} - Whether to produce also a JSON serializer function using `fast-json-stringify`. The default stringifier function is `JSON.stringify`
 
 #### compiledQuery.compiled(root: any, context: any, variables: Maybe<{ [key: string]: any }>)
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ the compiled function that can be called with a root value, a context and the re
 
 #### compiledQuery.stringify(value: any)
 
-the compiled function for producing a JSON string. It will be `JSON.stringify` unless `compilerOptions.customJSONSerializer` is true.
+the compiled function for producing a JSON string. It will be `JSON.stringify` unless `compilerOptions.fastJson` is set.
 The value argument should the return of the compiled GraphQL function.
 
 ## LICENSE

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@types/benchmark": "^1.0.31",
     "@types/graphql": "^14.2.0",
     "@types/jest": "^24.0.11",
-    "@types/json-schema": "^7.0.1",
     "@types/lodash.memoize": "^4.1.6",
     "@types/lodash.merge": "^4.6.6",
     "@types/lodash.mergewith": "^4.6.6",
@@ -77,7 +76,6 @@
   },
   "dependencies": {
     "generate-function": "^2.3.1",
-    "json-schema": "^0.2.3",
     "lodash.memoize": "^4.1.2",
     "lodash.merge": "4.6.2",
     "lodash.mergewith": "4.6.2"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/node": "^10.11.7",
     "benchmark": "^2.1.4",
     "codecov": "^3.3.0",
+    "fast-json-stringify": "^2.0.1",
     "graphql": "^15.0.0",
     "graphql-tools": "^4.0.4",
     "jest": "^24.7.1",
@@ -75,7 +76,6 @@
     "typescript": "^3.4.2"
   },
   "dependencies": {
-    "fast-json-stringify": "^1.13.0",
     "generate-function": "^2.3.1",
     "json-schema": "^0.2.3",
     "lodash.memoize": "^4.1.2",

--- a/src/__tests__/__snapshots__/json.test.ts.snap
+++ b/src/__tests__/__snapshots__/json.test.ts.snap
@@ -4,6 +4,7 @@ exports[`json schema creator json schema creation 1`] = `
 Object {
   "properties": Object {
     "data": Object {
+      "nullable": true,
       "properties": Object {
         "article": Object {
           "properties": Object {
@@ -127,10 +128,7 @@ Object {
           ],
         },
       },
-      "type": Array [
-        "object",
-        "null",
-      ],
+      "type": "object",
     },
     "errors": Object {
       "items": Object {

--- a/src/__tests__/__snapshots__/json.test.ts.snap
+++ b/src/__tests__/__snapshots__/json.test.ts.snap
@@ -7,6 +7,7 @@ Object {
       "nullable": true,
       "properties": Object {
         "article": Object {
+          "nullable": true,
           "properties": Object {
             "author": Object {
               "properties": Object {
@@ -14,118 +15,85 @@ Object {
                   "type": "string",
                 },
                 "name": Object {
-                  "type": Array [
-                    "string",
-                    "null",
-                  ],
+                  "nullable": true,
+                  "type": "string",
                 },
                 "pic": Object {
+                  "nullable": true,
                   "properties": Object {
                     "height": Object {
-                      "type": Array [
-                        "integer",
-                        "null",
-                      ],
+                      "nullable": true,
+                      "type": "integer",
                     },
                     "url": Object {
-                      "type": Array [
-                        "string",
-                        "null",
-                      ],
+                      "nullable": true,
+                      "type": "string",
                     },
                     "width": Object {
-                      "type": Array [
-                        "integer",
-                        "null",
-                      ],
+                      "nullable": true,
+                      "type": "integer",
                     },
                   },
-                  "type": Array [
-                    "object",
-                    "null",
-                  ],
+                  "type": "object",
                 },
                 "recentArticle": Object {
+                  "nullable": true,
                   "properties": Object {
                     "body": Object {
-                      "type": Array [
-                        "string",
-                        "null",
-                      ],
+                      "nullable": true,
+                      "type": "string",
                     },
                     "id": Object {
                       "type": "string",
                     },
                     "isPublished": Object {
-                      "type": Array [
-                        "boolean",
-                        "null",
-                      ],
+                      "nullable": true,
+                      "type": "boolean",
                     },
                     "title": Object {
-                      "type": Array [
-                        "string",
-                        "null",
-                      ],
+                      "nullable": true,
+                      "type": "string",
                     },
                   },
-                  "type": Array [
-                    "object",
-                    "null",
-                  ],
+                  "type": "object",
                 },
               },
               "type": "object",
             },
             "body": Object {
-              "type": Array [
-                "string",
-                "null",
-              ],
+              "nullable": true,
+              "type": "string",
             },
             "id": Object {
               "type": "string",
             },
             "isPublished": Object {
-              "type": Array [
-                "boolean",
-                "null",
-              ],
+              "nullable": true,
+              "type": "boolean",
             },
             "title": Object {
-              "type": Array [
-                "string",
-                "null",
-              ],
+              "nullable": true,
+              "type": "string",
             },
           },
-          "type": Array [
-            "object",
-            "null",
-          ],
+          "type": "object",
         },
         "feed": Object {
           "items": Object {
+            "nullable": true,
             "properties": Object {
               "id": Object {
                 "type": "string",
               },
               "title": Object {
-                "type": Array [
-                  "string",
-                  "null",
-                ],
+                "nullable": true,
+                "type": "string",
               },
             },
-            "type": Array [
-              "object",
-              "null",
-            ],
+            "type": "object",
           },
-          "type": Array [
-            "array",
-            "null",
-          ],
+          "nullable": true,
+          "type": "array",
         },
       },
       "type": "object",

--- a/src/__tests__/json.test.ts
+++ b/src/__tests__/json.test.ts
@@ -148,16 +148,14 @@ describe("json schema creator", () => {
     });
     test("valid response serialization", async () => {
       const prepared: any = compileQuery(blogSchema, parse(query), "", {
-        customJSONSerializer: true
+        fastJson: require('fast-json-stringify')
       });
       const response = await prepared.query(undefined, undefined, {});
       expect(prepared.stringify).not.toBe(JSON.stringify);
       expect(prepared.stringify(response)).toEqual(JSON.stringify(response));
     });
     test("valid response serialization 2", async () => {
-      const prepared: any = compileQuery(blogSchema, parse(query), "", {
-        customJSONSerializer: false
-      });
+      const prepared: any = compileQuery(blogSchema, parse(query), "");
       expect(prepared.stringify).toBe(JSON.stringify);
     });
     test("error response serialization", async () => {

--- a/src/__tests__/json.test.ts
+++ b/src/__tests__/json.test.ts
@@ -148,7 +148,7 @@ describe("json schema creator", () => {
     });
     test("valid response serialization", async () => {
       const prepared: any = compileQuery(blogSchema, parse(query), "", {
-        fastJson: require('fast-json-stringify')
+        fastJson: require("fast-json-stringify")
       });
       const response = await prepared.query(undefined, undefined, {});
       expect(prepared.stringify).not.toBe(JSON.stringify);

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -62,7 +62,10 @@ import {
 const inspect = createInspect();
 
 export interface CompilerOptions {
-  fastJson?: (schema: ObjectSchema, options?: FastJSONOptions) => (doc: string) => string;
+  fastJson?: (
+    schema: ObjectSchema,
+    options?: FastJSONOptions
+  ) => (doc: string) => string;
 
   // Disable builtin scalars and enum serialization
   // which is responsible for coercion,
@@ -208,7 +211,7 @@ export function compileQuery(
       fastJson: undefined,
       customSerializers: {},
       ...partialOptions
-    }
+    };
 
     // If a valid context cannot be created due to incorrect arguments,
     // a "Response" with only errors is returned.

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -202,11 +202,13 @@ export function compileQuery(
     throw new Error("resolverInfoEnricher must be a function");
   }
   try {
-    const options = Object.assign(partialOptions || {}, {
+    const options = {
       disablingCapturingStackErrors: false,
       disableLeafSerialization: false,
+      fastJson: undefined,
       customSerializers: {},
-    })
+      ...partialOptions
+    }
 
     // If a valid context cannot be created due to incorrect arguments,
     // a "Response" with only errors is returned.

--- a/src/json.ts
+++ b/src/json.ts
@@ -14,6 +14,7 @@ import {
   isObjectType,
   isScalarType
 } from "graphql";
+import { ObjectSchema } from 'fast-json-stringify'
 import { collectFields, ExecutionContext } from "graphql/execution/execute";
 import { JSONSchema6, JSONSchema6TypeName } from "json-schema";
 import { collectSubfields, resolveFieldDef } from "./ast";
@@ -32,7 +33,7 @@ const PRIMITIVES: { [key: string]: JSONSchema6TypeName } = {
  * @param exeContext
  * @return     {object}  A plain JavaScript object which conforms to JSON Schema
  */
-export function queryToJSONSchema(exeContext: ExecutionContext): JSONSchema6 {
+export function queryToJSONSchema(exeContext: ExecutionContext): ObjectSchema {
   const type = getOperationRootType(exeContext.schema, exeContext.operation);
   const fields = collectFields(
     exeContext,
@@ -59,8 +60,9 @@ export function queryToJSONSchema(exeContext: ExecutionContext): JSONSchema6 {
     type: "object",
     properties: {
       data: {
-        type: ["object", "null"],
-        properties: fieldProperties
+        type: "object",
+        properties: fieldProperties,
+        nullable: true
       },
       errors: {
         type: "array",

--- a/src/json.ts
+++ b/src/json.ts
@@ -4,6 +4,15 @@
  * @type       {<type>}
  */
 import {
+  ArraySchema,
+  BooleanSchema,
+  IntegerSchema,
+  NullSchema,
+  NumberSchema,
+  ObjectSchema,
+  StringSchema
+} from "fast-json-stringify";
+import {
   FieldNode,
   getOperationRootType,
   GraphQLType,
@@ -14,11 +23,16 @@ import {
   isObjectType,
   isScalarType
 } from "graphql";
-import { ObjectSchema, ArraySchema, StringSchema, NumberSchema, BooleanSchema, IntegerSchema, NullSchema, Schema } from 'fast-json-stringify'
 import { collectFields, ExecutionContext } from "graphql/execution/execute";
 import { collectSubfields, resolveFieldDef } from "./ast";
 
-const PRIMITIVES: { [key: string]: (StringSchema | NumberSchema | BooleanSchema | IntegerSchema)['type'] } = {
+const PRIMITIVES: {
+  [key: string]: (
+    | StringSchema
+    | NumberSchema
+    | BooleanSchema
+    | IntegerSchema)["type"];
+} = {
   Int: "integer",
   Float: "number",
   String: "string",
@@ -103,7 +117,14 @@ function transformNode(
   exeContext: ExecutionContext,
   fieldNodes: FieldNode[],
   type: GraphQLType
-): ObjectSchema | ArraySchema | StringSchema | NumberSchema | BooleanSchema | IntegerSchema | NullSchema {
+):
+  | ObjectSchema
+  | ArraySchema
+  | StringSchema
+  | NumberSchema
+  | BooleanSchema
+  | IntegerSchema
+  | NullSchema {
   if (isObjectType(type)) {
     const subfields = collectSubfields(exeContext, type, fieldNodes);
     const properties = Object.create(null);
@@ -139,13 +160,15 @@ function transformNode(
   }
   if (isNonNullType(type)) {
     const nullable = transformNode(exeContext, fieldNodes, type.ofType);
-    if ('nullable' in nullable) delete nullable.nullable;
+    if ("nullable" in nullable) {
+      delete nullable.nullable;
+    }
     return nullable;
   }
   if (isEnumType(type)) {
     return {
       type: "string",
-      nullable: true,
+      nullable: true
     };
   }
   if (isScalarType(type)) {
@@ -153,14 +176,18 @@ function transformNode(
     if (jsonSchemaType) {
       return {
         type: jsonSchemaType,
-        nullable: true,
+        nullable: true
       } as StringSchema | NumberSchema | BooleanSchema | IntegerSchema;
     }
   }
   if (isAbstractType(type)) {
     return exeContext.schema.getPossibleTypes(type).reduce(
       (res, t) => {
-        const jsonSchema = transformNode(exeContext, fieldNodes, t) as ObjectSchema;
+        const jsonSchema = transformNode(
+          exeContext,
+          fieldNodes,
+          t
+        ) as ObjectSchema;
         res.properties = { ...res.properties, ...jsonSchema.properties };
         return res;
       },

--- a/types/fast-json-stringify.d.ts
+++ b/types/fast-json-stringify.d.ts
@@ -1,1 +1,0 @@
-declare module "fast-json-stringify";

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,12 +519,12 @@ ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.8.1:
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
-  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+ajv@^6.11.0:
+  version "6.12.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
+  integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
   dependencies:
-    fast-deep-equal "^2.0.1"
+    fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
@@ -1231,10 +1231,10 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.2.0.tgz#58ef463a57c08d376547f8869fdc5bcee957f44e"
-  integrity sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow==
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 default-require-extensions@^2.0.0:
   version "2.0.0"
@@ -1536,10 +1536,10 @@ fast-deep-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
   integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
 
-fast-deep-equal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
-  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+fast-deep-equal@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-diff@^1.1.1:
   version "1.2.0"
@@ -1551,13 +1551,14 @@ fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
-fast-json-stringify@^1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stringify/-/fast-json-stringify-1.13.0.tgz#fd9bbc65a5ac083a8f4b53528fe21f7baa0ff0f7"
-  integrity sha512-3B+ENtJyVFBbcTodTQ0VC8NMWvb7R33S8RetnhjMJ12Nw85Hf4Ku9Enm8xqY6llLlmXUU+iNJ49c3/+C3/HiJw==
+fast-json-stringify@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-json-stringify/-/fast-json-stringify-2.0.1.tgz#f8d7bfba7e705a1ef319954196a86e26691f9853"
+  integrity sha512-n3LQfUhYTk2p95RxPA0BEfzmAcCdJLCRQ0qphNiXMBmxHgteiCtUfBYc7ZNCzBTBWm/kHg81CI+hkxVwIHWTAw==
   dependencies:
-    ajv "^6.8.1"
-    deepmerge "^3.0.0"
+    ajv "^6.11.0"
+    deepmerge "^4.2.2"
+    string-similarity "^4.0.1"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -4281,6 +4282,11 @@ string-length@^2.0.0:
   dependencies:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
+
+string-similarity@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.1.tgz#ea7c11f0093cb3088cdcc5eb16cfd90cb54962f7"
+  integrity sha512-v36MJzloekKVvKAsYi6O/qpn2mIuvwEFIT9Gx3yg4spkNjXYsk7yxc37g4ZTyMVIBvt/9PZGxnqEtme8XHK+Mw==
 
 string-width@^1.0.1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,11 +416,6 @@
   dependencies:
     "@types/jest-diff" "*"
 
-"@types/json-schema@^7.0.1":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.1.tgz#fcaa655260285b8061850789f8268c51a4ec8ee1"
-  integrity sha512-NVQEMviDWjuen3UW+mU1J6fZ0WhOfG1yRce/2OTcbaz+fgmTw2cahx6N2wh0Yl+a+hg2UZj/oElZmtULWyGIsA==
-
 "@types/lodash.memoize@^4.1.6":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.memoize/-/lodash.memoize-4.1.6.tgz#3221f981790a415cab1a239f25c17efd8b604c23"
@@ -2802,7 +2797,7 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
-json-schema@0.2.3, json-schema@^0.2.3:
+json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=


### PR DESCRIPTION
Close #83 

This is still up to discussion and may be closed if it deems likewise. This is a breaking change

```
const fastJson = require('fast-json-stringify')
const { compileQuery } = require("graphql-jit");

const compiledQuery = compileQuery(schema, document, { fastJson });
```

Caveat: 
- This may be confusing for end-user.
- `queryToJSONSchema` is tightly coupled with `fast-json-stringify` ([`nullable` prop](https://github.com/fastify/fast-json-stringify#nullable))
- May break if `fast-json-stringify` has breaking change.