### PR TITLE
Upgrade TypeScript to 3.9.5 (fixing a tiny bug in the process)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/lodash.memoize": "^4.1.6",
     "@types/lodash.merge": "^4.6.6",
     "@types/lodash.mergewith": "^4.6.6",
-    "@types/node": "^10.11.7",
+    "@types/node": "^10.17.26",
     "benchmark": "^2.1.4",
     "codecov": "^3.3.0",
     "graphql": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "tslint": "^5.15.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-plugin-prettier": "^2.0.1",
-    "typescript": "^3.4.2"
+    "typescript": "^3.9.5"
   },
   "dependencies": {
     "fast-json-stringify": "^1.13.0",

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -335,7 +335,7 @@ export function getArgumentDefs(
 
 interface MissingVariablePath {
   valueNode: VariableNode;
-  path: ObjectPath;
+  path?: ObjectPath;
   argument?: { definition: GraphQLArgument; node: ArgumentNode };
 }
 

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -1130,7 +1130,10 @@ function getValidArgumentsVarName(prefixName: string) {
   return `${prefixName}ValidArgs`;
 }
 
-function objectPath(topLevel: string, path: ObjectPath) {
+function objectPath(topLevel: string, path?: ObjectPath) {
+  if (!path) {
+    return topLevel;
+  }
   let objectPath = topLevel;
   const flattened = flattenPath(path);
   for (const section of flattened) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,10 +447,10 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.117.tgz#695a7f514182771a1e0f4345d189052ee33c8778"
   integrity sha512-xyf2m6tRbz8qQKcxYZa7PA4SllYcay+eh25DN3jmNYY6gSTL7Htc/bttVdkqj2wfJGbeWlQiX8pIyJpKU+tubw==
 
-"@types/node@^10.11.7":
-  version "10.11.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.11.7.tgz#0e75ca9357d646ca754016ca1d68a127ad7e7300"
-  integrity sha512-yOxFfkN9xUFLyvWaeYj90mlqTJ41CsQzWKS3gXdOMOyPVacUsymejKxJ4/pMW7exouubuEeZLJawGgcNGYlTeg==
+"@types/node@^10.17.26":
+  version "10.17.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.26.tgz#a8a119960bff16b823be4c617da028570779bcfd"
+  integrity sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4636,10 +4636,10 @@ typed-rest-client@~1.4.0:
     tunnel "0.0.4"
     underscore "1.8.3"
 
-typescript@^3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.2.tgz#9ed4e6475d906f589200193be056f5913caed481"
-  integrity sha512-Og2Vn6Mk7JAuWA1hQdDQN/Ekm/SchX80VzLhjKN9ETYrIepBFAd8PkOdOTK2nKt0FCkmMZKBJvQ1dV1gIxPu/A==
+typescript@^3.9.5:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
While working on a different issue, I noticed `graphql-jit` didn't typecheck on newer TypeScripts. This bumps the compiler version used in development and fixes two small issues that arose from the bump. See the commits for a description of each! 

