### PR TITLE
Preserve original error

### DIFF
--- a/src/variables.ts
+++ b/src/variables.ts
@@ -277,7 +277,9 @@ function generateInput(
           } catch (error) {
             errors.push(new GraphQLJITError('Variable "$${varName}" got invalid value ' +
               inspect(${currentInput}) + "; " +
-              'Expected type ${varType.name}.', ${errorLocation})
+              'Expected type ${
+                varType.name
+              }.', ${errorLocation}, undefined, error)
             );
           }
         `);


### PR DESCRIPTION
This is an attempt to address issue #92.
After going through the codebase, I managed to find where the `originalError` is lost in my use case, when an error is thrown from custom directive.
After these changes, I'm able to preserve the `originalError`.