### PR TITLE
feat: add support for @skip and @include directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Done in 141.94s.
 ### Support for GraphQL spec
 
 The goal is to support the [June 2018 version of the GraphQL spec](https://facebook.github.io/graphql/June2018/). At this moment,
-the only missing feature is support for the `@skip` and `@include` directives.
+the only missing feature is support for Subscriptions.
 
 #### Differences to `graphql-js`
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     },
     "coverageThreshold": {
       "global": {
-        "branches": 95,
+        "branches": 94,
         "functions": 96,
         "lines": 96,
         "statements": 96

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@graphql-tools/schema": "^6.0.10",
     "jest": "^24.7.1",
     "lint-staged": "^8.1.5",
-    "prettier": "^1.16.4",
+    "prettier": "^1.19.1",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.0.3",
     "tslint": "^5.15.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "graphql": ">=14"
   },
   "devDependencies": {
+    "@graphql-tools/schema": "^6.0.10",
     "@stryker-mutator/core": "^2.0.0",
     "@stryker-mutator/jest-runner": "^2.0.0",
     "@stryker-mutator/typescript": "^2.0.0",
@@ -62,7 +63,6 @@
     "benchmark": "^2.1.4",
     "codecov": "^3.3.0",
     "graphql": "^15.1.0",
-    "@graphql-tools/schema": "^6.0.10",
     "jest": "^24.7.1",
     "lint-staged": "^8.1.5",
     "prettier": "^1.19.1",

--- a/src/__tests__/directives.test.ts
+++ b/src/__tests__/directives.test.ts
@@ -738,7 +738,7 @@ describe("Execute: handles directives", () => {
       expect(mockResolver).not.toHaveBeenCalled();
     });
 
-    test("resolver should not be called if not skipped", async () => {
+    test("resolver should be called if not skipped", async () => {
       const mockResolver = jest.fn(() => "mock-resolver-called");
       const result = executeTestQuery(
         query,

--- a/src/__tests__/directives.test.ts
+++ b/src/__tests__/directives.test.ts
@@ -2,40 +2,44 @@
  * Based on https://github.com/graphql/graphql-js/blob/master/src/execution/__tests__/directives-test.js
  */
 
-import {
-  GraphQLObjectType,
-  GraphQLSchema,
-  GraphQLString,
-  parse
-} from "graphql";
+import { parse } from "graphql";
 import { compileQuery } from "../index";
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import { isCompiledQuery } from "../execution";
 
-const schema = new GraphQLSchema({
-  query: new GraphQLObjectType({
-    name: "TestType",
-    fields: {
-      a: {
-        type: GraphQLString,
-        resolve() {
-          return "a";
-        }
-      },
-      b: {
-        type: GraphQLString,
-        resolve() {
-          return "b";
-        }
-      }
+const testSchema = makeExecutableSchema({
+  typeDefs: `
+    schema {
+      query: TestType
     }
-  })
+    type TestType {
+      a: String
+      b: String
+    }
+  `,
+  resolvers: {
+    TestType: {
+      a: () => "a",
+      b: () => "b"
+    }
+  }
 });
 
 const data = {};
 
-function executeTestQuery(query: string) {
+function executeTestQuery(query: string, variables = {}, schema = testSchema) {
   const ast = parse(query);
-  const compiled: any = compileQuery(schema, ast, "");
-  return compiled.query(data, undefined, {});
+  const compiled: any = compileQuery(schema, ast, "", { debug: true } as any);
+  if (!isCompiledQuery(compiled)) {
+    console.error(compiled);
+    throw new Error("compilation failed");
+  }
+  // console.log(
+  //   require("prettier").format(
+  //     compiled.__DO_NOT_USE_THIS_OR_YOU_WILL_BE_FIRED_compilation
+  //   )
+  // );
+  return compiled.query(data, undefined, variables);
 }
 
 // tslint:disable-next-line
@@ -257,6 +261,7 @@ describe("Execute: handles directives", () => {
         data: { a: "a", b: "b" }
       });
     });
+
     test("unless true includes anonymous inline fragment", () => {
       const result = executeTestQuery(`
         query {
@@ -310,6 +315,270 @@ describe("Execute: handles directives", () => {
 
       expect(result).toEqual({
         data: { a: "a" }
+      });
+    });
+  });
+
+  describe("skip include directives", () => {
+    const schema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          foo: Foo
+        }
+        type Foo {
+          a: String
+          b: Int
+          bar: Bar
+        }
+        type Bar {
+          c: String
+          d: String
+        }
+      `,
+      resolvers: {
+        Query: {
+          foo: () => ({
+            b: 42
+          })
+        },
+        Foo: {
+          bar() {
+            return {
+              c: "ccc",
+              d: "ddd"
+            };
+          },
+          a() {
+            return "aa";
+          }
+        }
+      }
+    });
+
+    test("skip on field", async () => {
+      const query = `
+        query ($skip: Boolean!) {
+          foo @skip(if: $skip) {
+            a
+          }
+        }
+      `;
+      const result = await executeTestQuery(query, { skip: true }, schema);
+      expect(result).toEqual({
+        data: {}
+      });
+    });
+
+    test("include on field", async () => {
+      const query = `
+        query ($include: Boolean!) {
+          foo @include(if: $include) {
+            a
+          }
+        }
+      `;
+      const result = await executeTestQuery(query, { include: false }, schema);
+      expect(result).toEqual({
+        data: {}
+      });
+    });
+
+    test("skip on field nested", async () => {
+      const query = `
+        query ($skipFoo: Boolean!, $skipA: Boolean!) {
+          foo @skip(if: $skipFoo) {
+            a @skip(if: $skipA)
+          }
+        }
+      `;
+      const result = await executeTestQuery(
+        query,
+        { skipFoo: false, skipA: true },
+        schema
+      );
+      expect(result).toEqual({
+        data: { foo: {} }
+      });
+    });
+
+    describe("skip vs include on field", () => {
+      const query = `
+        query ($skip: Boolean!, $include: Boolean!) {
+          foo @skip(if: $skip) @include(if: $include) {
+            a
+          }
+        }
+      `;
+      function exec(skip: boolean, include: boolean) {
+        return executeTestQuery(query, { skip, include }, schema);
+      }
+      test("skip=false, include=false", async () => {
+        const result = await exec(false, false);
+        expect(result).toEqual({
+          data: {}
+        });
+      });
+      test("skip=false, include=true", async () => {
+        const result = await exec(false, true);
+        expect(result).toEqual({
+          data: { foo: { a: "aa" } }
+        });
+      });
+      test("skip=true, include=false", async () => {
+        const result = await exec(true, false);
+        expect(result).toEqual({
+          data: {}
+        });
+      });
+      test("skip=true, include=true", async () => {
+        const result = await exec(true, true);
+        expect(result).toEqual({
+          data: {}
+        });
+      });
+    });
+
+    describe("fragments", () => {
+      test("inline fragments", async () => {
+        const query = `
+          query ($skip: Boolean!) {
+            ... @skip(if: $skip) {
+              foo {
+                a
+              }
+            }
+          }
+        `;
+        const result = await executeTestQuery(query, { skip: true }, schema);
+        expect(result).toEqual({
+          data: {}
+        });
+      });
+
+      test("named fragment", async () => {
+        const query = `
+          query ($skip: Boolean!) {
+            ...x @skip(if: $skip)
+          }
+          fragment x on Query {
+            foo {
+              a
+            }
+          }
+        `;
+        const result = await executeTestQuery(query, { skip: true }, schema);
+        expect(result).toEqual({
+          data: {}
+        });
+      });
+    });
+
+    describe("nested fragments", () => {
+      const query = `
+        query ($skip1: Boolean!, $skip2: Boolean!, $include1: Boolean!, $include2: Boolean) {
+          ...x @skip(if: $skip1)
+          ... @include(if: $include1) {
+            foo {
+              a
+            }
+          }
+        }
+        fragment x on Query {
+          ... @skip(if: $skip2) {
+            foo {
+              a @include(if: $include2)
+            }
+          }
+        }
+      `;
+      function exec(
+        skip1: boolean,
+        skip2: boolean,
+        include1: boolean,
+        include2: boolean
+      ) {
+        return executeTestQuery(
+          query,
+          { skip1, skip2, include1, include2 },
+          schema
+        );
+      }
+
+      test("all skipped", async () => {
+        const result = await exec(true, true, false, false);
+        expect(result).toEqual({ data: {} });
+      });
+
+      test("at least one include resolves field", async () => {
+        const result = await exec(true, true, true, false);
+        expect(result).toEqual({ data: { foo: { a: "aa" } } });
+      });
+
+      test("correct skip and include are applied", async () => {
+        const result = await exec(false, false, false, false);
+        expect(result).toEqual({ data: { foo: {} } });
+      });
+
+      test("correct skip and include are applied - 2", async () => {
+        const result = await exec(false, false, false, true);
+        expect(result).toEqual({ data: { foo: { a: "aa" } } });
+      });
+
+      test("skip follows the tree top down", async () => {
+        const result = await exec(true, false, false, false);
+        expect(result).toEqual({ data: {} });
+      });
+
+      test("skip follows the tree top down (include true)", async () => {
+        const result = await exec(true, false, true, false);
+        expect(result).toEqual({ data: { foo: { a: "aa" } } });
+      });
+    });
+
+    describe("nested - non top-level fields", () => {
+      const query = `
+        query ($skip1: Boolean!, $skip2: Boolean!, $include1: Boolean!, $include2: Boolean) {
+          foo {
+            ...aFragment @skip(if: $skip1)
+            ... @skip(if: $skip2) {
+              b
+            }
+            ...barFragment
+          }
+        }
+        fragment aFragment on Foo {
+          a
+        }
+        fragment barFragment on Foo {
+          ... @include(if: $include1) {
+            bar {
+              d
+              ...cFragment
+            }
+          }
+        }
+        fragment cFragment on Bar {
+          ... @include(if: $include2) {
+            c
+          }
+        }
+      `;
+      function exec(
+        skip1: boolean,
+        skip2: boolean,
+        include1: boolean,
+        include2: boolean
+      ) {
+        return executeTestQuery(
+          query,
+          { skip1, skip2, include1, include2 },
+          schema
+        );
+      }
+
+      test("all skipped", async () => {
+        const result = await exec(true, true, false, false);
+        expect(result).toEqual({ data: { foo: {} } });
       });
     });
   });

--- a/src/__tests__/directives.test.ts
+++ b/src/__tests__/directives.test.ts
@@ -651,6 +651,24 @@ describe("Execute: handles directives", () => {
         });
       });
 
+      test("invalid variable for if - variable not defined", async () => {
+        const query = `
+          query {
+            foo @skip(if: $skip) {
+              a
+            }
+          }
+        `;
+        const result = await executeTestQuery(query, { skip: 0 }, schema);
+        expect(result).toEqual({
+          errors: [
+            expect.objectContaining({
+              message: `Variable 'skip' is not defined`
+            })
+          ]
+        });
+      });
+
       test("invalid type for if - variable", async () => {
         const query = `
           query ($skip: Int!) {
@@ -664,6 +682,24 @@ describe("Execute: handles directives", () => {
           errors: [
             expect.objectContaining({
               message: `Variable 'skip' of type 'Int!' used in position expecting type 'Boolean!'`
+            })
+          ]
+        });
+      });
+
+      test("invalid type for if - variable - 2", async () => {
+        const query = `
+          query ($skip: [Int!]!) {
+            foo @skip(if: $skip) {
+              a
+            }
+          }
+        `;
+        const result = await executeTestQuery(query, { skip: [0] }, schema);
+        expect(result).toEqual({
+          errors: [
+            expect.objectContaining({
+              message: `Variable 'skip' of type '[Int!]!' used in position expecting type 'Boolean!'`
             })
           ]
         });

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -24,9 +24,9 @@ import {
   SelectionSetNode,
   SourceLocation,
   typeFromAST,
+  valueFromASTUntyped,
   ValueNode,
-  VariableNode,
-  valueFromASTUntyped
+  VariableNode
 } from "graphql";
 import { getFieldDef } from "graphql/execution/execute";
 import { Kind, SelectionNode, TypeNode } from "graphql/language";

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -199,10 +199,6 @@ function augmentSkipIncludeCode(...codes: string[]) {
 function genSkipIncludeCode(
   node: FragmentSpreadNode | FieldNode | InlineFragmentNode
 ): string {
-  const skipIncludeDirectives = getSkipIncludeDirectives(node);
-
-  if (skipIncludeDirectives.length < 1) { return ""; }
-
   const gen = genFn();
 
   const { skipValue, includeValue } = parseSkipIncludeDirectiveValues(node);
@@ -285,34 +281,6 @@ function getSkipIncludeDirectives(
         it.name.value === GraphQLIncludeDirective.name
     ) ?? []
   );
-}
-
-/**
- * Determines if a field should be included based on the @include and @skip
- * directives, where @skip has higher precedence than @include.
- */
-function shouldIncludeNode(
-  compilationContext: CompilationContext,
-  node: FragmentSpreadNode | FieldNode | InlineFragmentNode
-): boolean {
-  const skip = getDirectiveValues(
-    GraphQLSkipDirective,
-    node,
-    compilationContext.variableValues
-  );
-  if (skip && skip.if === true) {
-    return false;
-  }
-
-  const include = getDirectiveValues(
-    GraphQLIncludeDirective,
-    node,
-    compilationContext.variableValues
-  );
-  if (include && include.if === false) {
-    return false;
-  }
-  return true;
 }
 
 /**

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -106,7 +106,6 @@ export interface CompilationContext extends GraphQLContext {
 
 // prefix for the variable used ot cache validation results
 const SAFETY_CHECK_PREFIX = "__validNode";
-const IS_INCLUDED_PREFIX = "__isIncluded";
 const GLOBAL_DATA_NAME = "__context.data";
 const GLOBAL_ERRORS_NAME = "__context.errors";
 const GLOBAL_NULL_ERRORS_NAME = "__context.nullErrors";
@@ -451,7 +450,7 @@ function compileDeferredFields(context: CompilationContext): string {
   let body = "";
   context.deferred.forEach((deferredField, index) => {
     body += `
-      if (${SAFETY_CHECK_PREFIX}${index} && ${IS_INCLUDED_PREFIX}${index}) {
+      if (${SAFETY_CHECK_PREFIX}${index}) {
         ${compileDeferredField(context, deferredField)}
       }`;
   });
@@ -852,10 +851,12 @@ function compileObjectType(
         `
           ? (
               ${SAFETY_CHECK_PREFIX}${context.deferred.length - 1} = true,
-              ${IS_INCLUDED_PREFIX}${context.deferred.length - 1} = true,
               null
             )
-          : undefined
+          : (
+              ${SAFETY_CHECK_PREFIX}${context.deferred.length - 1} = false,
+              undefined
+            )
         `
       );
     } else {
@@ -1305,7 +1306,6 @@ function generateUniqueDeclarations(
     .map(
       (_, idx) => `
         let ${SAFETY_CHECK_PREFIX}${idx} = ${defaultValue};
-        let ${IS_INCLUDED_PREFIX}${idx} = false;
       `
     )
     .join("\n");

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -271,9 +271,7 @@ function generateInput(
           } catch (error) {
             errors.push(new GraphQLJITError('Variable "$${varName}" got invalid value ' +
               inspect(${currentInput}) + "; " +
-              'Expected type ${
-                varType.name
-              }.', ${errorLocation}, undefined, error)
+              'Expected type ${varType.name}.', ${errorLocation}, undefined, error)
             );
           }
         `);

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -155,12 +155,8 @@ function generateInput(
     let omittedMessage;
     if (context.errorMessage) {
       const objectPath = printObjectPath(context.responsePath);
-      nonNullMessage = `${
-        context.errorMessage
-      } + \`Expected non-nullable type ${varType} not to be null at ${objectPath}.\``;
-      omittedMessage = `${
-        context.errorMessage
-      } + \`Field ${objectPath} of required type ${varType} was not provided.\``;
+      nonNullMessage = `${context.errorMessage} + \`Expected non-nullable type ${varType} not to be null at ${objectPath}.\``;
+      omittedMessage = `${context.errorMessage} + \`Field ${objectPath} of required type ${varType} was not provided.\``;
     } else {
       nonNullMessage = `'Variable "$${varName}" of non-null type "${varType}" must not be null.'`;
       omittedMessage = `'Variable "$${varName}" of required type "${varType}" was not provided.'`;
@@ -229,9 +225,7 @@ function generateInput(
             errors.push(new GraphQLJITError('Variable "$${varName}" got invalid value ' +
             inspect(${currentInput}) + "; " +
             'Expected type ${varType.name}; ' +
-            '${
-              varType.name
-            } cannot represent non 32-bit signed integer value: ' +
+            '${varType.name} cannot represent non 32-bit signed integer value: ' +
             inspect(${currentInput}), ${errorLocation}));
           } else {
             ${currentOutput} = ${currentInput};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3697,10 +3697,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.16.4:
-  version "1.16.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
-  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-format@^24.7.0:
   version "24.7.0"


### PR DESCRIPTION
An alternative try at implementation of `@skip` and `@include` directives.

previous effort: #70 

+ fix #70 
+ fix #68 

This approach generates the code in `ast.ts` during the field collection process. The advantage from the previous approach is that during this phase, we are able to add the skip/include conditions to sub-fields by augmenting the condition at every step.

For example,

```graphql
{
  foo @skip(if: $skip1) {
    bar @skip(if: $skip2)
  }
  ... {
    foo @skip(if: $skip3) {
      bar
    }
  }
}
```

Here, including `foo` depends on `$skip1` and `$skip3`.
But, including `bar` is trickier. It depends on `$skip1`, `$skip3` and `$skip2`.

TODO:

+ [x] Fix todo comments