### PR TITLE
Move publishing to GH

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Node.js Package
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    # Setup .npmrc file to publish to npm
+    - uses: actions/setup-node@v12
+      with:
+        node-version: 14
+        registry-url: 'https://registry.npmjs.org'
+    - run: yarn install
+    - run: yarn publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     # Setup .npmrc file to publish to npm
-    - uses: actions/setup-node@v12
+    - uses: actions/setup-node@v2
       with:
         node-version: 14
         registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
Travis publishing is broken.

Content copied from https://docs.github.com/en/actions/guides/publishing-nodejs-packages#publishing-packages-using-yarn