### PR TITLE
fix: update graphql peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     }
   },
   "peerDependencies": {
-    "graphql": ">=14"
+    "graphql": ">=15"
   },
   "devDependencies": {
     "@graphql-tools/schema": "^6.0.10",


### PR DESCRIPTION
This project uses graphql 15 to run all tests. Update peerDependency to use the same. 