### PR TITLE
fix empty objects on nested inline fragments

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -261,7 +261,7 @@ function augmentFieldNodeTree(
       }
       case Kind.INLINE_FRAGMENT: {
         for (const subSelection of selection.selectionSet.selections) {
-          handle(parentFieldNode, subSelection);
+          handle(parentFieldNode, subSelection, true);
         }
         break;
       }


### PR DESCRIPTION
fix https://github.com/zalando-incubator/graphql-jit/issues/118
Basically its apply same change (https://github.com/zalando-incubator/graphql-jit/pull/113#discussion_r627264937) to inline fragments
