### PR TITLE
Publish v0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-jit",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "GraphQL JIT Compiler to JS",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
- fix empty objects on nested inline fragments (#119) [@fjmoreno]
- fix [RangeError: invalid String length] or OOM (#120) [@fjmoreno]

