### PR TITLE
Add TypedDocumentNode support

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "typescript": "^3.9.5"
   },
   "dependencies": {
+    "@graphql-typed-document-node/core": "3.1.0",
     "fast-json-stringify": "^1.13.0",
     "generate-function": "^2.3.1",
     "json-schema": "^0.2.3",

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -1,3 +1,4 @@
+import { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import fastJson from "fast-json-stringify";
 import genFn from "generate-function";
 import {
@@ -61,7 +62,6 @@ import {
   compileVariableParsing,
   failToParseVariables
 } from "./variables";
-import { TypedDocumentNode } from "@graphql-typed-document-node/core";
 
 const inspect = createInspect();
 
@@ -163,7 +163,10 @@ interface DeferredField {
   args: Arguments;
 }
 
-export interface CompiledQuery<TResult = { [key: string]: any }, TVariables = { [key: string]: any }> {
+export interface CompiledQuery<
+  TResult = { [key: string]: any },
+  TVariables = { [key: string]: any }
+> {
   operationName?: string;
   query: (
     root: any,
@@ -174,7 +177,9 @@ export interface CompiledQuery<TResult = { [key: string]: any }, TVariables = { 
     root: any,
     context: any,
     variables: Maybe<TVariables>
-  ) => Promise<AsyncIterableIterator<ExecutionResult<TResult>> | ExecutionResult<TResult>>;
+  ) => Promise<
+    AsyncIterableIterator<ExecutionResult<TResult>> | ExecutionResult<TResult>
+  >;
   stringify: (v: any) => string;
 }
 
@@ -190,7 +195,10 @@ interface InternalCompiledQuery extends CompiledQuery {
  * @param partialOptions compilation options to tune the compiler features
  * @returns {CompiledQuery} the cacheable result
  */
-export function compileQuery<TResult = { [key: string]: any }, TVariables = { [key: string]: any }>(
+export function compileQuery<
+  TResult = { [key: string]: any },
+  TVariables = { [key: string]: any }
+>(
   schema: GraphQLSchema,
   document: TypedDocumentNode<TResult, TVariables>,
   operationName?: string,

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -287,7 +287,7 @@ export function compileQuery<TResult = { [key: string]: any }, TVariables = { [k
       compiledQuery.__DO_NOT_USE_THIS_OR_YOU_WILL_BE_FIRED_compilation = functionBody;
     }
     return compiledQuery as CompiledQuery<TResult, TVariables>;
-  } catch (err: any) {
+  } catch (err) {
     return {
       errors: normalizeErrors(err)
     };
@@ -1446,7 +1446,7 @@ function getSerializer(
         return null;
       }
       return value;
-    } catch (e: any) {
+    } catch (e) {
       onError(
         context,
         (e && e.message) ||

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -1718,7 +1718,7 @@ function compileSubscriptionOperation(
         throw eventStream;
       }
       return eventStream;
-    } catch (error: any) {
+    } catch (error) {
       throw locatedError(
         error,
         resolveInfo.fieldNodes,

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,6 +162,11 @@
     aggregate-error "3.0.1"
     camel-case "4.1.1"
 
+"@graphql-typed-document-node/core@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
+  integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
+
 "@jest/console@^24.7.1":
   version "24.7.1"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"


### PR DESCRIPTION
Thank you for this great library!
This PR adds `TypedDocumentNode` support to `graphql-jit`. For example, generated `TypedDocumentNode` queries will have type safe signature with `graphql-jit`.
It also enables to use generics in `CompiledQuery` to have better type safety.
https://github.com/dotansimha/graphql-typed-document-node