### PR TITLE
Unit tests for input defaults

### DIFF
--- a/src/__tests__/variables.test.ts
+++ b/src/__tests__/variables.test.ts
@@ -75,7 +75,7 @@ const TestInputObjectWithDefaultValue = new GraphQLInputObjectType({
   name: "TestInputObjectWithDefaultValue",
   fields: {
     a: { type: GraphQLString },
-    b: { type: GraphQLString, defaultValue: "default" },
+    b: { type: GraphQLString, defaultValue: "default" }
   }
 });
 
@@ -128,7 +128,9 @@ const TestType = new GraphQLObjectType({
     fieldWithNonNullableEnumInput: fieldWithInputArg({
       type: new GraphQLNonNull(TestEnum)
     }),
-    fieldWithDefaultInputValue: fieldWithInputArg({ type: TestInputObjectWithDefaultValue }),
+    fieldWithDefaultInputValue: fieldWithInputArg({
+      type: TestInputObjectWithDefaultValue
+    }),
     fieldWithObjectInput: fieldWithInputArg({ type: TestInputObject }),
     fieldWithObjectThrowingInput: fieldWithInputArg({
       type: TestThrowingInputObject
@@ -1602,11 +1604,14 @@ describe("Execute: Handles inputs", () => {
     });
 
     test("allows inputs with default values to be ommited from variable", async () => {
-      const result = await executeQuery(`
+      const result = await executeQuery(
+        `
         query ($value: TestInputObjectWithDefaultValue!) {
           fieldWithDefaultInputValue(input: $value)
         }
-      `, { value: { a: "test" } });
+      `,
+        { value: { a: "test" } }
+      );
 
       expect(result).toEqual({
         data: {
@@ -1614,7 +1619,7 @@ describe("Execute: Handles inputs", () => {
         }
       });
     });
-  })
+  });
 
   describe("Execute: Uses argument default values", () => {
     test("when no argument provided", async () => {

--- a/src/__tests__/variables.test.ts
+++ b/src/__tests__/variables.test.ts
@@ -1603,7 +1603,7 @@ describe("Execute: Handles inputs", () => {
       });
     });
 
-    test("allows inputs with default values to be ommited from variable", async () => {
+    test.skip("allows inputs with default values to be ommited from variable", async () => {
       const result = await executeQuery(
         `
         query ($value: TestInputObjectWithDefaultValue!) {


### PR DESCRIPTION
Added unit tests for testing that input default values are working. Currently default values are not applied for inputs that are coming from variables that is discussed in issue #142.