### PR TITLE
Update benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GraphQL JIT
 
-[![Build Status](https://travis-ci.org/zalando-incubator/graphql-jit.svg?branch=master)](https://travis-ci.org/zalando-incubator/graphql-jit)
+![npm](https://img.shields.io/npm/dw/graphql-jit)
 [![codecov](https://codecov.io/gh/zalando-incubator/graphql-jit/branch/master/graph/badge.svg)](https://codecov.io/gh/zalando-incubator/graphql-jit)
 
 ### Why?
@@ -10,21 +10,22 @@ code which yields much better performance. `graphql-jit` leverages this behaviou
 
 #### Benchmarks
 
+GraphQL-JS 16 on Node 16.13.0
 ```bash
 $ yarn benchmark skip-json
 Starting introspection
-graphql-js x 1,155 ops/sec ±1.55% (215 runs sampled)
-graphql-jit x 5,961 ops/sec ±5.34% (216 runs sampled)
+graphql-js x 1,941 ops/sec ±2.50% (225 runs sampled)
+graphql-jit x 6,158 ops/sec ±2.38% (222 runs sampled)
 Starting fewResolvers
-graphql-js x 14,313 ops/sec ±1.43% (224 runs sampled)
-graphql-jit x 409,587 ops/sec ±1.08% (216 runs sampled)
+graphql-js x 26,620 ops/sec ±2.41% (225 runs sampled)
+graphql-jit x 339,223 ops/sec ±2.94% (215 runs sampled)
 Starting manyResolvers
-graphql-js x 13,201 ops/sec ±1.50% (216 runs sampled)
-graphql-jit x 229,025 ops/sec ±1.18% (216 runs sampled)
+graphql-js x 16,415 ops/sec ±2.36% (220 runs sampled)
+graphql-jit x 178,331 ops/sec ±2.73% (221 runs sampled)
 Starting nestedArrays
-graphql-js x 108 ops/sec ±1.30% (216 runs sampled)
-graphql-jit x 1,317 ops/sec ±2.38% (213 runs sampled)
-Done in 141.94s.
+graphql-js x 127 ops/sec ±1.43% (220 runs sampled)
+graphql-jit x 1,316 ops/sec ±2.58% (219 runs sampled)
+Done in 141.25s.
 ```
 
 ### Support for GraphQL spec


### PR DESCRIPTION
The latest Graphql-js has improved its performance.
Also remove the travis badge since we moved to GH actions and replace with NPM downloads.