### PR TITLE
Bump release to 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-jit",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "GraphQL JIT Compiler to JS",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
json-schema is a public dependency so a new release is needed.