### PR TITLE
Better error message in default type resolver

### DIFF
--- a/src/execution.ts
+++ b/src/execution.ts
@@ -1507,7 +1507,10 @@ function defaultResolveTypeFn(
     }
   }
 
-  throw new Error(`Could not resolve the object type in possible types of ${abstractType.name} for the value: ` + inspect(value));
+  throw new Error(
+    `Could not resolve the object type in possible types of ${abstractType.name} for the value: ` +
+      inspect(value)
+  );
 }
 
 /**

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -1507,7 +1507,7 @@ function defaultResolveTypeFn(
     }
   }
 
-  throw new Error(`Could not resolve type of ${value}`);
+  throw new Error(`Could not resolve the object type in possible types of ${abstractType.name} for the value: ` + inspect(value));
 }
 
 /**


### PR DESCRIPTION
The error is so cryptic if type isn't resolved by default type resolver. So this PR improves that issue.