### PR TITLE
fix: update @graphql-typed-document-node/core for graphql@16 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@graphql-typed-document-node/core": "3.1.0",
+    "@graphql-typed-document-node/core": "3.1.1",
     "fast-json-stringify": "^1.13.0",
     "generate-function": "^2.3.1",
     "json-schema": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@graphql-typed-document-node/core": "3.1.1",
+    "@graphql-typed-document-node/core": "^3.1.1",
     "fast-json-stringify": "^1.13.0",
     "generate-function": "^2.3.1",
     "json-schema": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -471,7 +471,7 @@
   dependencies:
     tslib "~2.3.0"
 
-"@graphql-typed-document-node/core@3.1.1":
+"@graphql-typed-document-node/core@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
   integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -471,10 +471,10 @@
   dependencies:
     tslib "~2.3.0"
 
-"@graphql-typed-document-node/core@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
-  integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
+"@graphql-typed-document-node/core@3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
+  integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
 "@humanwhocodes/config-array@^0.6.0":
   version "0.6.0"


### PR DESCRIPTION
Not sure why the version is locked down, but 3.1.0 does not have `graphql@16` in its peer dependency range