### PR TITLE
chore: link to repo correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git@github.com:ruiaraujo/graphql-jit.git"
+    "url": "https://github.com/zalando-incubator/graphql-jit.git"
   },
   "scripts": {
     "precommit": "lint-staged",


### PR DESCRIPTION
I had issues finding this repo since it's not linked from npmjs.com.

https://www.npmjs.com/package/graphql-jit
<img width="421" alt="image" src="https://user-images.githubusercontent.com/1404810/154054305-29ad6cb5-fad3-497a-9cdf-c74bab43101a.png">

I assume it's the git url instead of http and not the wrong user, but who knows.

docs: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#repository