### PR TITLE
fix: update deprecated API from graphql-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.1",
     "eslint-plugin-standard": "^5.0.0",
-    "graphql": "^16.0.0",
+    "graphql": "^16.3.0",
     "jest": "^27.4.3",
     "lint-staged": "^8.1.5",
     "prettier": "^2.4.1",

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -6,7 +6,6 @@ import {
   DocumentNode,
   ExecutionResult,
   FragmentDefinitionNode,
-  getOperationRootType,
   GraphQLAbstractType,
   GraphQLEnumType,
   GraphQLError,
@@ -248,7 +247,7 @@ export function compileQuery<
       context.operation.variableDefinitions || []
     );
 
-    const type = getOperationRootType(context.schema, context.operation);
+    const type = context.schema.getRootType(context.operation.operation)!;
     const fieldMap = collectFields(
       context,
       type,

--- a/src/json.ts
+++ b/src/json.ts
@@ -5,7 +5,6 @@
  */
 import {
   FieldNode,
-  getOperationRootType,
   GraphQLType,
   isAbstractType,
   isEnumType,
@@ -35,10 +34,9 @@ const PRIMITIVES: { [key: string]: JSONSchema6TypeName } = {
 export function queryToJSONSchema(
   compilationContext: CompilationContext
 ): JSONSchema6 {
-  const type = getOperationRootType(
-    compilationContext.schema,
-    compilationContext.operation
-  );
+  const type = compilationContext.schema.getRootType(
+    compilationContext.operation.operation
+  )!;
   const fields = collectFields(
     compilationContext,
     type,

--- a/src/non-null.ts
+++ b/src/non-null.ts
@@ -1,7 +1,6 @@
 import {
   ExecutionResult,
   FieldNode,
-  getOperationRootType,
   GraphQLError,
   GraphQLType,
   isListType,
@@ -135,10 +134,9 @@ function findNullableAncestor(
 function parseQueryNullables(
   compilationContext: CompilationContext
 ): QueryMetadata {
-  const type = getOperationRootType(
-    compilationContext.schema,
-    compilationContext.operation
-  );
+  const type = compilationContext.schema.getRootType(
+    compilationContext.operation.operation
+  )!;
   const fields = collectFields(
     compilationContext,
     type,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2657,10 +2657,10 @@ graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-graphql@^16.0.0:
-  version "16.2.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.2.0.tgz#de3150e80f1fc009590b92a9d16ab1b46e12b656"
-  integrity sha512-MuQd7XXrdOcmfwuLwC2jNvx0n3rxIuNYOxUtiee5XOmfrWo613ar2U8pE7aHAKh8VwfpifubpD9IP+EdEAEOsA==
+graphql@^16.3.0:
+  version "16.3.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.3.0.tgz#a91e24d10babf9e60c706919bb182b53ccdffc05"
+  integrity sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==
 
 has-ansi@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
`getOperationRootType` is deprecated in graphql-js. The new API is `schema.getRootType(operation)`

Deprecation notice

https://github.com/graphql/graphql-js/blob/47bd8c8897c72d3efc17ecb1599a95cee6bac5e8/src/utilities/getOperationRootType.ts#L11-L15