### PR TITLE
fix: update deprecated API in GraphQL JS to new API

### DIFF
--- a/src/compat.ts
+++ b/src/compat.ts
@@ -21,6 +21,7 @@ export function getOperationRootType(
   if (GraphQL.getOperationRootType) {
     return GraphQL.getOperationRootType(schema, operation);
   } else {
-    return schema.getRootType(operation.operation)!;
+    // the use of any is to support graphql v15 types which will not use this codepath
+    return (schema as any).getRootType(operation.operation)!;
   }
 }

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -1,0 +1,26 @@
+import * as GraphQL from "graphql";
+
+/**
+ * A helper to support backward compatibility for different versions of graphql-js.
+ *
+ * v15 does not have schema.getRootType
+ * v16 has both
+ * v17 will not have getOperationRootType
+ *
+ * To support all these 3 versions of graphql-js, at least for migration, this helper
+ * would be useful.
+ *
+ * This can be removed once we drop support for v15.
+ *
+ * GraphQL v17 would remove getOperationRootType.
+ */
+export function getOperationRootType(
+  schema: GraphQL.GraphQLSchema,
+  operation: GraphQL.OperationDefinitionNode
+) {
+  if (GraphQL.getOperationRootType) {
+    return GraphQL.getOperationRootType(schema, operation);
+  } else {
+    return schema.getRootType(operation.operation)!;
+  }
+}

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -47,6 +47,7 @@ import {
   ObjectPath,
   resolveFieldDef
 } from "./ast";
+import { getOperationRootType } from "./compat";
 import { GraphQLError as GraphqlJitError } from "./error";
 import createInspect from "./inspect";
 import { queryToJSONSchema } from "./json";
@@ -247,7 +248,7 @@ export function compileQuery<
       context.operation.variableDefinitions || []
     );
 
-    const type = context.schema.getRootType(context.operation.operation)!;
+    const type = getOperationRootType(context.schema, context.operation);
     const fieldMap = collectFields(
       context,
       type,

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -6,7 +6,6 @@ import {
   DocumentNode,
   ExecutionResult,
   FragmentDefinitionNode,
-  getOperationRootType,
   GraphQLAbstractType,
   GraphQLEnumType,
   GraphQLError,
@@ -248,7 +247,7 @@ export function compileQuery<
       context.operation.variableDefinitions || []
     );
 
-    const type = getOperationRootType(context.schema, context.operation);
+    const type = context.schema.getRootType(context.operation.operation)!;
     const fieldMap = collectFields(
       context,
       type,

--- a/src/json.ts
+++ b/src/json.ts
@@ -15,6 +15,7 @@ import {
 } from "graphql";
 import { JSONSchema6, JSONSchema6TypeName } from "json-schema";
 import { collectFields, collectSubfields, resolveFieldDef } from "./ast";
+import { getOperationRootType } from "./compat";
 import { CompilationContext } from "./execution";
 
 const PRIMITIVES: { [key: string]: JSONSchema6TypeName } = {
@@ -34,9 +35,10 @@ const PRIMITIVES: { [key: string]: JSONSchema6TypeName } = {
 export function queryToJSONSchema(
   compilationContext: CompilationContext
 ): JSONSchema6 {
-  const type = compilationContext.schema.getRootType(
-    compilationContext.operation.operation
-  )!;
+  const type = getOperationRootType(
+    compilationContext.schema,
+    compilationContext.operation
+  );
   const fields = collectFields(
     compilationContext,
     type,

--- a/src/json.ts
+++ b/src/json.ts
@@ -5,7 +5,6 @@
  */
 import {
   FieldNode,
-  getOperationRootType,
   GraphQLType,
   isAbstractType,
   isEnumType,
@@ -35,10 +34,9 @@ const PRIMITIVES: { [key: string]: JSONSchema6TypeName } = {
 export function queryToJSONSchema(
   compilationContext: CompilationContext
 ): JSONSchema6 {
-  const type = getOperationRootType(
-    compilationContext.schema,
-    compilationContext.operation
-  );
+  const type = compilationContext.schema.getRootType(
+    compilationContext.operation.operation
+  )!;
   const fields = collectFields(
     compilationContext,
     type,

--- a/src/non-null.ts
+++ b/src/non-null.ts
@@ -1,7 +1,6 @@
 import {
   ExecutionResult,
   FieldNode,
-  getOperationRootType,
   GraphQLError,
   GraphQLType,
   isListType,
@@ -135,10 +134,9 @@ function findNullableAncestor(
 function parseQueryNullables(
   compilationContext: CompilationContext
 ): QueryMetadata {
-  const type = getOperationRootType(
-    compilationContext.schema,
-    compilationContext.operation
-  );
+  const type = compilationContext.schema.getRootType(
+    compilationContext.operation.operation
+  )!;
   const fields = collectFields(
     compilationContext,
     type,

--- a/src/non-null.ts
+++ b/src/non-null.ts
@@ -10,6 +10,7 @@ import {
 import { isAbstractType } from "graphql/type";
 import merge from "lodash.merge";
 import { collectFields, collectSubfields, resolveFieldDef } from "./ast";
+import { getOperationRootType } from "./compat";
 import { CompilationContext } from "./execution";
 
 interface QueryMetadata {
@@ -134,9 +135,10 @@ function findNullableAncestor(
 function parseQueryNullables(
   compilationContext: CompilationContext
 ): QueryMetadata {
-  const type = compilationContext.schema.getRootType(
-    compilationContext.operation.operation
-  )!;
+  const type = getOperationRootType(
+    compilationContext.schema,
+    compilationContext.operation
+  );
   const fields = collectFields(
     compilationContext,
     type,


### PR DESCRIPTION
getOperationRootType is deprecated in graphql-js and will be removed in v17. The PR updates to the new API - schema.getRootType.