### PR TITLE
Drop build for Node 12, add 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16, 18]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         graphql-version: [15, 16]
 


### PR DESCRIPTION
Node version 12 is end of lifetime, so drop that from build jobs.

The current LTS version is 18, so add that to build jobs.