### PR TITLE
fix: validation for skip/include with default values

### DIFF
--- a/src/__tests__/directives.test.ts
+++ b/src/__tests__/directives.test.ts
@@ -1383,4 +1383,54 @@ describe("Execute: handles directives", () => {
       expect(mockResolver).toHaveBeenCalled();
     });
   });
+
+  describe("default values in include / skip directive's if", () => {
+    test("default value true in include", () => {
+      const result = executeTestQuery(`
+        query myQuery($inc: Boolean = true) {
+          a @include(if: $inc)
+        }
+      `);
+
+      expect(result).toEqual({
+        data: { a: "a" }
+      });
+    });
+
+    test("default value false in include", () => {
+      const result = executeTestQuery(`
+        query myQuery($inc: Boolean = false) {
+          a @include(if: $inc)
+        }
+      `);
+
+      expect(result).toEqual({
+        data: {}
+      });
+    });
+
+    test("default value true in skip", () => {
+      const result = executeTestQuery(`
+        query myQuery($skip: Boolean = true) {
+          a @skip(if: $skip)
+        }
+      `);
+
+      expect(result).toEqual({
+        data: {}
+      });
+    });
+
+    test("default value false in skip", () => {
+      const result = executeTestQuery(`
+        query myQuery($skip: Boolean = false) {
+          a @skip(if: $skip)
+        }
+      `);
+
+      expect(result).toEqual({
+        data: { a: "a" }
+      });
+    });
+  });
 });

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -459,11 +459,19 @@ function validateSkipIncludeVariableType(
     ]);
   }
 
+  // Part of Spec text: https://spec.graphql.org/June2018/#sec-All-Variable-Usages-are-Allowed
   if (
     !(
-      variableDefinition.type.kind === Kind.NON_NULL_TYPE &&
-      variableDefinition.type.type.kind === Kind.NAMED_TYPE &&
-      variableDefinition.type.type.name.value === "Boolean"
+      // The variable defintion is a Non-nullable Boolean type
+      (
+        (variableDefinition.type.kind === Kind.NON_NULL_TYPE &&
+          variableDefinition.type.type.kind === Kind.NAMED_TYPE &&
+          variableDefinition.type.type.name.value === "Boolean") ||
+        // or the variable definition is a nullable Boolean type with a default value
+        (variableDefinition.type.kind === Kind.NAMED_TYPE &&
+          variableDefinition.type.name.value === "Boolean" &&
+          variableDefinition.defaultValue != null)
+      )
     )
   ) {
     throw new GraphQLError(


### PR DESCRIPTION
fix #190

Corresponding spec text: https://spec.graphql.org/June2018/#sec-All-Variable-Usages-are-Allowed

When validation the variable definition for the argument `if` for the directives skip/include, the default values in the variable definition were not considered. This PR fixes the issue by correctly using the default values in the variable definition.