### PR TITLE
Bump release to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-jit",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "GraphQL JIT Compiler to JS",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
#### Breaking Changes:

- Drop build for Node 12, add 18 (#188)

#### Bug fixes:

- fix: validation for skip/include with default values (#193)
- fix: field expansion - fill only relevant fields while traversing abstract types (#180)
- fix: update deprecated API in GraphQL JS to new API (#179)

#### Version updates:

- Bump minimatch from 3.0.4 to 3.1.2 (#192)
- Bump decode-uri-component from 0.2.0 to 0.2.2 (#186)
- Bump json5 from 1.0.1 to 1.0.2 (#187)

#### Other changes:

- Add test case to json.test.ts (#191)