### PR TITLE
Bump release to 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-jit",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "GraphQL JIT Compiler to JS",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Bug Fixes:

- fix: skip include logic handling multiple paths to same node (PR: #197) (Issue: #166)

This release introduces a new CompilerOption `useExperimentalPathBasedSkipInclude`. If you have multiple "fragment spreads" pointing to the same fragment and use skip include inside the fragment, it is recommended to use this option to avoid a bug. In future releases, this option will be removed when it becomes the default.

For example,

```ts
const compiledQuery = compileQuery(
  schema, ast, operationName,
  {
    useExperimentalPathBasedSkipInclude: true
  }
);
```