### PR TITLE
fix: use option to compute path based skip/include

### DIFF
--- a/src/__tests__/json.test.ts
+++ b/src/__tests__/json.test.ts
@@ -136,6 +136,7 @@ describe("json schema creator", () => {
           document
         })
       : (buildExecutionContext as any)(blogSchema, document);
+  context.options = {};
   const jsonSchema = queryToJSONSchema(context);
   test("json schema creation", () => {
     expect(jsonSchema).toMatchSnapshot();
@@ -213,6 +214,7 @@ describe("JSON schema creation with abstract types", () => {
           document
         })
       : (buildExecutionContext as any)(schema, document);
+  context.options = {};
 
   const jsonSchema = queryToJSONSchema(context);
   test("json schema creation", () => {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -142,20 +142,21 @@ function collectFieldsImpl(
          * -----------------------------
          * `should include`s generated for the current fieldNode
          */
-        fieldNode.__internalShouldIncludePath[currentPath] =
-          joinShouldIncludeCompilations(
-            fieldNode.__internalShouldIncludePath?.[currentPath] ?? "",
+        if (compilationContext.options.useExperimentalPathBasedSkipInclude) {
+          fieldNode.__internalShouldIncludePath[currentPath] =
+            joinShouldIncludeCompilations(
+              fieldNode.__internalShouldIncludePath?.[currentPath] ?? "",
+              previousShouldInclude,
+              compiledSkipInclude
+            );
+        } else {
+          // @deprecated
+          fieldNode.__internalShouldInclude = joinShouldIncludeCompilations(
+            fieldNode.__internalShouldInclude ?? "",
             previousShouldInclude,
             compiledSkipInclude
           );
-
-        // @deprecated
-        fieldNode.__internalShouldInclude = joinShouldIncludeCompilations(
-          fieldNode.__internalShouldInclude ?? "",
-          previousShouldInclude,
-          compiledSkipInclude
-        );
-
+        }
         /**
          * We augment the entire subtree as the parent object's skip/include
          * directives influence the child even if the child doesn't have
@@ -328,19 +329,22 @@ function augmentFieldNodeTree(
           if (!jitFieldNode.__internalShouldIncludePath)
             jitFieldNode.__internalShouldIncludePath = {};
 
-          jitFieldNode.__internalShouldIncludePath[currentPath] =
-            joinShouldIncludeCompilations(
-              parentFieldNode.__internalShouldIncludePath?.[
-                parentResponsePath
-              ] ?? "",
-              jitFieldNode.__internalShouldIncludePath?.[currentPath] ?? ""
-            );
-
-          // @deprecated
-          jitFieldNode.__internalShouldInclude = joinShouldIncludeCompilations(
-            parentFieldNode.__internalShouldInclude ?? "",
-            jitFieldNode.__internalShouldInclude ?? ""
-          );
+          if (compilationContext.options.useExperimentalPathBasedSkipInclude) {
+            jitFieldNode.__internalShouldIncludePath[currentPath] =
+              joinShouldIncludeCompilations(
+                parentFieldNode.__internalShouldIncludePath?.[
+                  parentResponsePath
+                ] ?? "",
+                jitFieldNode.__internalShouldIncludePath?.[currentPath] ?? ""
+              );
+          } else {
+            // @deprecated
+            jitFieldNode.__internalShouldInclude =
+              joinShouldIncludeCompilations(
+                parentFieldNode.__internalShouldInclude ?? "",
+                jitFieldNode.__internalShouldInclude ?? ""
+              );
+          }
         }
         // go further down the query tree
         for (const selection of jitFieldNode.selectionSet?.selections ?? []) {

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -873,25 +873,19 @@ function compileObjectType(
       name
     );
 
-    const oldFieldCondition =
-      fieldNodes
-        .map((it) => it.__internalShouldInclude)
-        .filter((it) => it)
-        .join(" || ") || /* if(true) - default */ "true";
-
-    const fieldCondition =
-      fieldNodes
-        .map((it) => it.__internalShouldIncludePath?.[serializedResponsePath])
-        .filter((it) => it)
-        .join(" || ") || /* if(true) - default */ "true";
+    const fieldCondition = context.options.useExperimentalPathBasedSkipInclude
+      ? fieldNodes
+          .map((it) => it.__internalShouldIncludePath?.[serializedResponsePath])
+          .filter((it) => it)
+          .join(" || ") || /* if(true) - default */ "true"
+      : fieldNodes
+          .map((it) => it.__internalShouldInclude)
+          .filter((it) => it)
+          .join(" || ") || /* if(true) - default */ "true";
 
     body(`
       (
-        ${
-          context.options.useExperimentalPathBasedSkipInclude
-            ? fieldCondition
-            : oldFieldCondition
-        }
+        ${fieldCondition}
       )
     `);
 


### PR DESCRIPTION
The previous fixes and additions to skip/include for fragment spreads #197 causes high event loop lag during compilation. This change is to compute the path based skip include only if the compiler option is set. Previously, we used the compiler option to only use it in the generated output - now it is also used for computation.