### PR TITLE
Bump release to 0.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-jit",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "GraphQL JIT Compiler to JS",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Fixes: 

- fix: improve event loop lag of compilation - use the option(useExperimentalPathBasedSkipInclude) to compute path based skip/include (#200)

The option introduced in the previous release https://github.com/zalando-incubator/graphql-jit/releases/tag/v0.8.1 will now be used in the computation of the skip include compiled code as well. This is to avoid high event-loop-lag observed in the previous release. 