### PR TITLE
Build on Node 20, drop 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [16, 18, 20]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         graphql-version: [15, 16, 17.0.0-alpha.2]
 


### PR DESCRIPTION
Node 14 is EOL, and Node 20 is now the current version.

Run tests on Node 20 instead of Node 14