### PR TITLE
Move object initalisation behind a feature toggle

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -123,9 +123,6 @@ function collectFieldsImpl(
           selection
         );
 
-        if (!fieldNode.__internalShouldIncludePath)
-          fieldNode.__internalShouldIncludePath = {};
-
         /**
          * Carry over fragment's skip and include code
          *
@@ -143,6 +140,9 @@ function collectFieldsImpl(
          * `should include`s generated for the current fieldNode
          */
         if (compilationContext.options.useExperimentalPathBasedSkipInclude) {
+          if (!fieldNode.__internalShouldIncludePath)
+            fieldNode.__internalShouldIncludePath = {};
+
           fieldNode.__internalShouldIncludePath[currentPath] =
             joinShouldIncludeCompilations(
               fieldNode.__internalShouldIncludePath?.[currentPath] ?? "",
@@ -326,10 +326,10 @@ function augmentFieldNodeTree(
         );
 
         if (!comesFromFragmentSpread) {
-          if (!jitFieldNode.__internalShouldIncludePath)
-            jitFieldNode.__internalShouldIncludePath = {};
-
           if (compilationContext.options.useExperimentalPathBasedSkipInclude) {
+            if (!jitFieldNode.__internalShouldIncludePath)
+              jitFieldNode.__internalShouldIncludePath = {};
+
             jitFieldNode.__internalShouldIncludePath[currentPath] =
               joinShouldIncludeCompilations(
                 parentFieldNode.__internalShouldIncludePath?.[


### PR DESCRIPTION
Moved the initialisation of __internalShouldIncludePath under field node to happen behind the configuration option
compilationContext.options.useExperimentalPathBasedSkipInclude.

The context for the change is that updating from 0.8.0 to 0.8.2 has shown increased Garbage Collector rates in use cases with big queries, and this change could be used to verify the hypothesis whether the initialisation of __internalShouldIncludePath is a cause for the GC runs.