### PR TITLE
Bump release to 0.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-jit",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "GraphQL JIT Compiler to JS",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Fixes:
- Move the initialization of `__internalShouldIncludePath` behind the option `useExperimentalPathBasedSkipInclude` to avoid unnecessary object generation and increased garbage collection runs when the feature is not in use #210 

The option introduced in the release https://github.com/zalando-incubator/graphql-jit/releases/tag/v0.8.1 will now be used to control initialization of field node metadata.  This is to avoid increased garbage collection runs observed in the previous release.

Dependency updates: 

- upgrade jest from v27.0.3 to v29.5.2 (https://github.com/zalando-incubator/graphql-jit/pull/206) 
- upgrade @graphql-typed-document-node/core from 3.1.1 to 3.1.2 (https://github.com/zalando-incubator/graphql-jit/pull/198) 
- upgrade fast-json-stringify to ^5.7.0 (https://github.com/zalando-incubator/graphql-jit/pull/203)
- upgrade @graphql-typed-document-node/core from 3.1.2 to 3.2.0 (https://github.com/zalando-incubator/graphql-jit/pull/207)