### PR TITLE
remove memoization to reduce memory pressure

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -33,7 +33,6 @@ import { isAbstractType } from "graphql/type";
 import { CompilationContext, GLOBAL_VARIABLES_NAME } from "./execution";
 import createInspect from "./inspect";
 import { getGraphQLErrorOptions, resolveFieldDef } from "./compat";
-import { memoize4 } from "./memoize";
 
 export interface JitFieldNode extends FieldNode {
   /**
@@ -627,14 +626,7 @@ function getFieldEntryKey(node: FieldNode): string {
 
 export { resolveFieldDef };
 
-/**
- * A memoized collection of relevant subfields in the context of the return
- * type. Memoizing ensures the subfields are not repeatedly calculated, which
- * saves overhead when resolving lists of values.
- */
-export const collectSubfields = memoize4(_collectSubfields);
-
-function _collectSubfields(
+export function collectSubfields(
   compilationContext: CompilationContext,
   returnType: GraphQLObjectType,
   fieldNodes: FieldNode[],


### PR DESCRIPTION
We observed recently that this function - 

1. does not hit the cache . 100% of the time for 4 parameters, the cache miss happens
2. It causes a lot of map objects - as a result of the cache miss, the nested map would create for more variance - and causes application to be slow. 
