### PR TITLE
Bump to GraphQL 17.alpha.3 for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         node-version: [16, 18, 20]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        graphql-version: [15, 16, 17.0.0-alpha.2]
+        graphql-version: [15, 16, 17.0.0-alpha.3]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Bump to the latest GraphQL alpha version when building