### PR TITLE
Drop node 16 from builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18, 20]
+        node-version: [18, 20]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         graphql-version: [15, 16, 17.0.0-alpha.2]
 


### PR DESCRIPTION
Node16 is EOL and does not need to be used in builds