### PR TITLE
fix: TS error usage before assigned

### DIFF
--- a/src/execution.ts
+++ b/src/execution.ts
@@ -1557,7 +1557,7 @@ function buildCompilationContext(
   operationName?: string
 ): CompilationContext {
   const errors: GraphQLError[] = [];
-  let operation: OperationDefinitionNode | void;
+  let operation: OperationDefinitionNode | void = undefined;
   let hasMultipleAssumedOperations = false;
   const fragments: { [key: string]: FragmentDefinitionNode } =
     Object.create(null);


### PR DESCRIPTION
Somehow only happens in editor and not in CI or build.

<img width="577" alt="Screenshot 2023-09-14 at 15 30 56" src="https://github.com/zalando-incubator/graphql-jit/assets/294474/6b61becc-5612-4e10-bfda-494a74cba502">
