### PR TITLE
chore: fix vuln report link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,7 @@
-We acknowledge that every line of code that we write may potentially contain security issues.
-We are trying to deal with it responsibly and provide patches as quickly as possible. 
+We acknowledge that every line of code that we write may potentially contain security issues. We are trying to deal with it responsibly and provide patches as quickly as possible.
 
 We host our bug bounty program on HackerOne, it is currently private, therefore if you would like to report a vulnerability and get rewarded for it, please ask to join our program by filling this form:
 
-https://corporate.zalando.com/en/services-and-contact#security-form
+https://corporate.zalando.com/about-us/report-vulnerability
 
-You can also send you report via this form if you do not want to join our bug bounty program and just want to report a vulnerability or security issue.
+You can also send your report via this form if you do not want to join our bug bounty program and just want to report a vulnerability or security issue.


### PR DESCRIPTION
The previous link does not have any form in that page.