### PR TITLE
support custom scalar type when using fast-json-stringify serializer

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eslint": "^8.49.0",
     "eslint-config-prettier": "^9.0.0",
     "graphql": "^16.8.0",
+    "graphql-scalars": "^1.22.4",
     "jest": "^29.7.0",
     "lint-staged": "^14.0.1",
     "prettier": "^3.0.3",

--- a/src/__tests__/__snapshots__/json.test.ts.snap
+++ b/src/__tests__/__snapshots__/json.test.ts.snap
@@ -66,6 +66,15 @@ exports[`json schema creator json schema creation 1`] = `
             "author": {
               "nullable": false,
               "properties": {
+                "email": {
+                  "nullable": true,
+                  "type": "string",
+                },
+                "extra": {
+                  "additionalProperties": true,
+                  "nullable": true,
+                  "type": "object",
+                },
                 "id": {
                   "nullable": false,
                   "type": "string",

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -51,7 +51,7 @@ import {
 } from "./ast";
 import { GraphQLError as GraphqlJitError } from "./error";
 import createInspect from "./inspect";
-import { queryToJSONSchema } from "./json";
+import { CustomScalarTypes, queryToJSONSchema } from "./json";
 import { createNullTrimmer, NullTrimmer } from "./non-null";
 import {
   createResolveInfoThunk,
@@ -69,6 +69,9 @@ const inspect = createInspect();
 
 export interface CompilerOptions {
   customJSONSerializer: boolean;
+
+  // To support serializing custom scalar type using fast-json-stringify
+  customJSONSerializerScalarTypes?: CustomScalarTypes;
 
   // Disable builtin scalars and enum serialization
   // which is responsible for coercion,
@@ -254,7 +257,10 @@ export function compileQuery<
 
     let stringify: (v: any) => string;
     if (options.customJSONSerializer) {
-      const jsonSchema = queryToJSONSchema(context);
+      const jsonSchema = queryToJSONSchema(
+        context,
+        options.customJSONSerializerScalarTypes
+      );
       stringify = fastJson(jsonSchema);
     } else {
       stringify = JSON.stringify;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2843,6 +2843,13 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+graphql-scalars@^1.22.4:
+  version "1.22.4"
+  resolved "https://registry.yarnpkg.com/graphql-scalars/-/graphql-scalars-1.22.4.tgz#af092b142bcfd5c1f8c53cb70ee1955ecd4ddb03"
+  integrity sha512-ILnv7jq5VKHLUyoaTFX7lgYrjCd6vTee9i8/B+D4zJKJT5TguOl0KkpPEbXHjmeor8AZYrVsrYUHdqRBMX1pjA==
+  dependencies:
+    tslib "^2.5.0"
+
 graphql@^16.8.0:
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.1.tgz#1930a965bef1170603702acdb68aedd3f3cf6f07"


### PR DESCRIPTION
When using fast-json-stringify serializer, custom scalar types are not supported.
To fix this, add option for queryToJSONSchema.