### PR TITLE
Bump build actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
         graphql-version: [15, 16, 17.0.0-alpha.3]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -30,7 +30,7 @@ jobs:
 
       # https://github.com/actions/cache/blob/main/examples.md#node---yarn
       - name: Cache yarn packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       # https://github.com/actions/cache/blob/main/examples.md#node---yarn
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       # https://github.com/actions/cache/blob/main/examples.md#node---yarn
       - name: Cache yarn packages


### PR DESCRIPTION
Bumped the build actions to v4 that uses Node20 by default, to avoid warnings of using outdated Node versions in actions

Updated the deprecated `set-output` to the new environment variables -based way to avoid warnings.