### PR TITLE
fix: support imports of form dist/*

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,22 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {
-    "import": "./dist/esm/index.js",
-    "require": "./dist/cjs/index.js"
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./dist": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./dist/*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js"
+    },
+    "./dist/*.js": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js"
+    }
   },
   "scripts": {
     "precommit": "lint-staged",


### PR DESCRIPTION
fix #241 

Allow the following imports - it was possible until #226 where we moved the output dirs. 

```ts
// index.js

require("graphql-jit/dist/error");
require("graphql-jit/dist/error.js");

// index.mjs

import "graphql-jit/dist/error";
import "graphql-jit/dist/error.js";
```