### PR TITLE
Bump GraphQL 17 version in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         node-version: [18, 20]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        graphql-version: [15, 16, 17.0.0-alpha.3]
+        graphql-version: [15, 16, 17.0.0-alpha.5]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
There is new alpha version 5 for GraphQL 17, so use it in builds to get results in the latest state of GraphQL 17.