### PR TITLE
fix: export ResolveInfoEnricherInput

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,5 +11,6 @@ export {
   LeafField,
   TypeExpansion,
   fieldExpansionEnricher,
-  isLeafField
+  isLeafField,
+  ResolveInfoEnricherInput
 } from "./resolve-info";


### PR DESCRIPTION
To use the `resolveInfoEnricher` functionality, it is required to export the type ResolveInfoEnricherInput, otherwise we find ourselves importing it from `graphql-jit/dist/resolve-info`.