### PR TITLE
feat: add canary releases for main branch

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -1,7 +1,10 @@
-name: Publish
+name: Publish Canary
 on:
-  release:
-    types: [created]
+  push:
+    branches:
+      - main
+    tags-ignore:
+      - 'v*'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +16,7 @@ jobs:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
       - run: yarn install
-      - run: yarn publish
+      - run: yarn version --prerelease --preid=canary
+      - run: yarn publish --tag canary --non-interactive
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add canary release for all main branch merges.

Automatically increment the canary version and publish it with tag `canary`. If the current version is `1.2.3`, the canary version would be `1.2.4-canary.0`, `1.2.4-canary.1`, etc.