### PR TITLE
fix: create new canary version from published pkg

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -16,7 +16,9 @@ jobs:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
       - run: yarn install
-      - run: yarn version --prerelease --preid=canary --no-git-tag-version
+      - run: node scripts/set-canary-version.js
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: yarn publish --tag canary --non-interactive
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@typescript-eslint/parser": "6.7.0",
     "benchmark": "^2.1.4",
     "codecov": "^3.8.2",
+    "compare-versions": "^6.1.1",
     "eslint": "^8.49.0",
     "eslint-config-prettier": "^9.0.0",
     "graphql": "^16.8.0",

--- a/scripts/set-canary-version.js
+++ b/scripts/set-canary-version.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+const fs = require("fs/promises");
+const path = require("path");
+const { execSync } = require("child_process");
+const { compareVersions } = require("compare-versions");
+
+const ROOT_DIR = path.join(__dirname, "..");
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+
+async function main() {
+  const pkg = require(path.join(ROOT_DIR, "package.json"));
+  const { name, version } = pkg;
+  const canaryVersion = getCanaryVersion(name);
+
+  const versionCompare = compareVersions(version, canaryVersion);
+
+  if (versionCompare > 0) {
+    console.info(
+      `${name} v${version} is greater than the published canary v${canaryVersion}! Creating new canary version.`
+    );
+
+    createNewCanaryVersion();
+    return;
+  } else {
+    console.info(
+      `${name} v${version} is less than the published canary v${canaryVersion}! Creating the next canary version.`
+    );
+
+    // set the current version to package.json
+    setPackageVersion(canaryVersion);
+
+    // create the next canary version
+    createNewCanaryVersion();
+  }
+}
+
+function getCanaryVersion(name) {
+  const manifestStr = execSync(`npm show ${name} dist-tags --json`).toString();
+  const manifest = JSON.parse(manifestStr);
+  return manifest.canary;
+}
+
+function createNewCanaryVersion() {
+  execSync(`yarn version --prerelease --preid=canary --no-git-tag-version`);
+}
+
+function setPackageVersion(version) {
+  execSync(`npm pkg set version=${version}`);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2519,6 +2519,11 @@ commander@^4.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
+compare-versions@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.1.1.tgz#7af3cc1099ba37d244b3145a9af5201b629148a9"
+  integrity sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"


### PR DESCRIPTION
Fixes - 

1. Create a new canary version instead of recreating the same canary version - because we are skipping git tag and git commit for canary publishes
2. Fix the NPM_TOKEN variable name
