### PR TITLE
fix: support esm; fix imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
       "js",
       "json"
     ],
+    "moduleNameMapper": {
+      "(.+)\\.js": "$1"
+    },
     "testEnvironment": "node",
     "testRegex": "(/tests/.*|(\\.|/)test)\\.ts$",
     "transform": {

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,38 +1,40 @@
 import genFn from "generate-function";
 import {
-  ArgumentNode,
-  ASTNode,
-  DirectiveNode,
-  FieldNode,
-  FragmentDefinitionNode,
+  type ArgumentNode,
+  type ASTNode,
+  type DirectiveNode,
+  type FieldNode,
+  type FragmentDefinitionNode,
   getLocation,
-  GraphQLArgument,
+  type GraphQLArgument,
   GraphQLDirective,
   GraphQLError,
-  GraphQLField,
+  type GraphQLField,
   GraphQLIncludeDirective,
-  GraphQLInputType,
+  type GraphQLInputType,
   GraphQLObjectType,
   GraphQLSkipDirective,
-  InlineFragmentNode,
+  type InlineFragmentNode,
   isEnumType,
   isInputObjectType,
   isListType,
   isNonNullType,
   isScalarType,
   print,
-  SelectionSetNode,
-  SourceLocation,
+  type SelectionSetNode,
+  type SourceLocation,
   typeFromAST,
   valueFromASTUntyped,
-  ValueNode,
-  VariableNode
+  type ValueNode,
+  type VariableNode,
+  Kind,
+  type SelectionNode,
+  type TypeNode,
+  isAbstractType
 } from "graphql";
-import { Kind, SelectionNode, TypeNode } from "graphql/language";
-import { isAbstractType } from "graphql/type";
-import { CompilationContext, GLOBAL_VARIABLES_NAME } from "./execution";
-import createInspect from "./inspect";
-import { getGraphQLErrorOptions, resolveFieldDef } from "./compat";
+import { type CompilationContext, GLOBAL_VARIABLES_NAME } from "./execution.js";
+import createInspect from "./inspect.js";
+import { getGraphQLErrorOptions, resolveFieldDef } from "./compat.js";
 
 export interface JitFieldNode extends FieldNode {
   /**

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -7,13 +7,12 @@ import {
   type ASTNode,
   type OperationDefinitionNode,
   type GraphQLObjectType,
-  formatError as formatErrorV15,
-  getOperationRootType as getOperationRootTypeV15
+  type GraphQLFormattedError
 } from "graphql";
 import { type Maybe } from "./types.js";
-import { type GraphQLFormattedError } from "graphql/error";
+import * as errorUtilities from "graphql/error/index.js";
+import * as utilities from "graphql/utilities/index.js";
 import { type CompilationContext } from "./execution.js";
-// uses internal graphql-js APIs
 import * as execute from "graphql/execution/execute.js";
 
 /**
@@ -37,7 +36,7 @@ export function getOperationRootType(
   operation: OperationDefinitionNode
 ): GraphQLObjectType {
   if (versionInfo.major < 16) {
-    return getOperationRootTypeV15(schema, operation);
+    return (utilities as any).getOperationRootType(schema, operation);
   }
 
   const type = (schema as any).getRootType(operation.operation);
@@ -55,7 +54,7 @@ export function getOperationRootType(
  */
 export function formatError(error: GraphQLError): GraphQLFormattedError {
   if (versionInfo.major < 16) {
-    return formatErrorV15(error);
+    return (errorUtilities as any).formatError(error);
   }
 
   return (error as any).toJSON();

--- a/src/compat.ts
+++ b/src/compat.ts
@@ -2,18 +2,19 @@ import {
   GraphQLSchema,
   GraphQLError,
   versionInfo,
-  FieldNode,
-  GraphQLField
+  type FieldNode,
+  type GraphQLField,
+  type ASTNode,
+  type OperationDefinitionNode,
+  type GraphQLObjectType,
+  formatError as formatErrorV15,
+  getOperationRootType as getOperationRootTypeV15
 } from "graphql";
-import { GraphQLObjectType } from "graphql/type/definition";
-import { Maybe } from "graphql/jsutils/Maybe";
-
-import { ASTNode, OperationDefinitionNode } from "graphql/language/ast";
-import * as errorUtilities from "graphql/error";
-import * as utilities from "graphql/utilities";
-import { GraphQLFormattedError } from "graphql/error";
-import { CompilationContext } from "./execution";
-import * as execute from "graphql/execution/execute";
+import { type Maybe } from "./types.js";
+import { type GraphQLFormattedError } from "graphql/error";
+import { type CompilationContext } from "./execution.js";
+// uses internal graphql-js APIs
+import * as execute from "graphql/execution/execute.js";
 
 /**
  * A helper file to support backward compatibility for different versions of graphql-js.
@@ -36,7 +37,7 @@ export function getOperationRootType(
   operation: OperationDefinitionNode
 ): GraphQLObjectType {
   if (versionInfo.major < 16) {
-    return (utilities as any).getOperationRootType(schema, operation);
+    return getOperationRootTypeV15(schema, operation);
   }
 
   const type = (schema as any).getRootType(operation.operation);
@@ -54,7 +55,7 @@ export function getOperationRootType(
  */
 export function formatError(error: GraphQLError): GraphQLFormattedError {
   if (versionInfo.major < 16) {
-    return (errorUtilities as any).formatError(error);
+    return formatErrorV15(error);
   }
 
   return (error as any).toJSON();

--- a/src/error.ts
+++ b/src/error.ts
@@ -2,7 +2,10 @@
  * Based on https://github.com/graphql/graphql-js/blob/master/src/error/GraphQLError.js
  */
 
-import { GraphQLError as UpstreamGraphQLError, SourceLocation } from "graphql";
+import {
+  GraphQLError as UpstreamGraphQLError,
+  type SourceLocation
+} from "graphql";
 
 export function GraphQLError(
   message: string,

--- a/src/execution.ts
+++ b/src/execution.ts
@@ -1,25 +1,25 @@
-import { TypedDocumentNode } from "@graphql-typed-document-node/core";
+import { type TypedDocumentNode } from "@graphql-typed-document-node/core";
 import fastJson from "fast-json-stringify";
 import genFn from "generate-function";
 import {
-  ASTNode,
-  DocumentNode,
-  ExecutionResult,
-  FragmentDefinitionNode,
-  GraphQLAbstractType,
+  type ASTNode,
+  type DocumentNode,
+  type ExecutionResult,
+  type FragmentDefinitionNode,
+  type GraphQLAbstractType,
   GraphQLEnumType,
   GraphQLError,
-  GraphQLFieldResolver,
-  GraphQLIsTypeOfFn,
-  GraphQLLeafType,
+  type GraphQLFieldResolver,
+  type GraphQLIsTypeOfFn,
+  type GraphQLLeafType,
   GraphQLList,
   GraphQLObjectType,
-  GraphQLOutputType,
-  GraphQLResolveInfo,
-  GraphQLScalarSerializer,
+  type GraphQLOutputType,
+  type GraphQLResolveInfo,
+  type GraphQLScalarSerializer,
   GraphQLScalarType,
   GraphQLSchema,
-  GraphQLType,
+  type GraphQLType,
   isAbstractType,
   isLeafType,
   isListType,
@@ -28,42 +28,43 @@ import {
   isSpecifiedScalarType,
   Kind,
   locatedError,
-  TypeNameMetaFieldDef
+  TypeNameMetaFieldDef,
+  type FieldNode,
+  type OperationDefinitionNode,
+  type GraphQLTypeResolver
 } from "graphql";
-import { ExecutionContext as GraphQLContext } from "graphql/execution/execute";
-import { pathToArray } from "graphql/jsutils/Path";
-import { FieldNode, OperationDefinitionNode } from "graphql/language/ast";
-import { GraphQLTypeResolver } from "graphql/type/definition";
+import { type ExecutionContext as GraphQLContext } from "graphql/execution/execute.js";
+import { pathToArray } from "graphql/jsutils/Path.js";
 import {
   addPath,
-  Arguments,
+  type Arguments,
   collectFields,
   collectSubfields,
   computeLocations,
-  FieldsAndNodes,
+  type FieldsAndNodes,
   flattenPath,
   getArgumentDefs,
-  JitFieldNode,
+  type JitFieldNode,
   joinSkipIncludePath,
-  ObjectPath,
+  type ObjectPath,
   resolveFieldDef,
   serializeObjectPathForSkipInclude
-} from "./ast";
-import { GraphQLError as GraphqlJitError } from "./error";
-import createInspect from "./inspect";
-import { queryToJSONSchema } from "./json";
-import { createNullTrimmer, NullTrimmer } from "./non-null";
+} from "./ast.js";
+import { GraphQLError as GraphqlJitError } from "./error.js";
+import createInspect from "./inspect.js";
+import { queryToJSONSchema } from "./json.js";
+import { createNullTrimmer, type NullTrimmer } from "./non-null.js";
 import {
   createResolveInfoThunk,
-  ResolveInfoEnricherInput
-} from "./resolve-info";
-import { Maybe } from "./types";
+  type ResolveInfoEnricherInput
+} from "./resolve-info.js";
+import { type Maybe } from "./types.js";
 import {
-  CoercedVariableValues,
+  type CoercedVariableValues,
   compileVariableParsing,
   failToParseVariables
-} from "./variables";
-import { getGraphQLErrorOptions, getOperationRootType } from "./compat";
+} from "./variables.js";
+import { getGraphQLErrorOptions, getOperationRootType } from "./compat.js";
 
 const inspect = createInspect();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,16 @@
 export {
   compileQuery,
   isCompiledQuery,
-  CompilerOptions,
-  CompiledQuery
-} from "./execution";
+  type CompilerOptions,
+  type CompiledQuery
+} from "./execution.js";
 
 export {
-  GraphQLJitResolveInfo,
-  FieldExpansion,
-  LeafField,
-  TypeExpansion,
+  type GraphQLJitResolveInfo,
+  type FieldExpansion,
+  type LeafField,
+  type TypeExpansion,
   fieldExpansionEnricher,
   isLeafField,
-  ResolveInfoEnricherInput
-} from "./resolve-info";
+  type ResolveInfoEnricherInput
+} from "./resolve-info.js";

--- a/src/json.ts
+++ b/src/json.ts
@@ -4,8 +4,8 @@
  * @type       {<type>}
  */
 import {
-  FieldNode,
-  GraphQLType,
+  type FieldNode,
+  type GraphQLType,
   isAbstractType,
   isEnumType,
   isListType,
@@ -14,17 +14,17 @@ import {
   isScalarType
 } from "graphql";
 import {
-  BooleanSchema,
-  IntegerSchema,
-  NumberSchema,
-  ObjectSchema,
-  RefSchema,
-  Schema,
-  StringSchema
+  type BooleanSchema,
+  type IntegerSchema,
+  type NumberSchema,
+  type ObjectSchema,
+  type RefSchema,
+  type Schema,
+  type StringSchema
 } from "fast-json-stringify";
-import { collectFields, collectSubfields, resolveFieldDef } from "./ast";
-import { getOperationRootType } from "./compat";
-import { CompilationContext } from "./execution";
+import { collectFields, collectSubfields, resolveFieldDef } from "./ast.js";
+import { getOperationRootType } from "./compat.js";
+import { type CompilationContext } from "./execution.js";
 
 const PRIMITIVES: {
   [key: string]:

--- a/src/non-null.ts
+++ b/src/non-null.ts
@@ -1,17 +1,17 @@
 import {
-  ExecutionResult,
-  FieldNode,
-  GraphQLError,
-  GraphQLType,
+  type ExecutionResult,
+  type FieldNode,
+  type GraphQLError,
+  type GraphQLType,
   isListType,
   isNonNullType,
-  isObjectType
+  isObjectType,
+  isAbstractType
 } from "graphql";
-import { isAbstractType } from "graphql/type";
 import merge from "lodash.merge";
-import { collectFields, collectSubfields, resolveFieldDef } from "./ast";
-import { getOperationRootType } from "./compat";
-import { CompilationContext } from "./execution";
+import { collectFields, collectSubfields, resolveFieldDef } from "./ast.js";
+import { getOperationRootType } from "./compat.js";
+import { type CompilationContext } from "./execution.js";
 
 interface QueryMetadata {
   isNullable: boolean;

--- a/src/resolve-info.ts
+++ b/src/resolve-info.ts
@@ -1,14 +1,14 @@
 import genFn from "generate-function";
 import {
   doTypesOverlap,
-  FieldNode,
-  GraphQLCompositeType,
+  type FieldNode,
+  type GraphQLCompositeType,
   GraphQLError,
   GraphQLInterfaceType,
-  GraphQLNamedType,
+  type GraphQLNamedType,
   GraphQLObjectType,
-  GraphQLOutputType,
-  GraphQLResolveInfo,
+  type GraphQLOutputType,
+  type GraphQLResolveInfo,
   GraphQLSchema,
   isAbstractType,
   isCompositeType,
@@ -17,11 +17,11 @@ import {
   isObjectType,
   isUnionType,
   Kind,
-  SelectionSetNode
+  type SelectionSetNode
 } from "graphql";
 import memoize from "lodash.memoize";
 import mergeWith from "lodash.mergewith";
-import { memoize2, memoize4 } from "./memoize";
+import { memoize2, memoize4 } from "./memoize.js";
 
 // TODO(boopathi): Use negated types to express
 // Enrichments<T> = { [key in (string & not keyof GraphQLResolveInfo)]: T[key] }

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -4,7 +4,7 @@ import {
   GraphQLError,
   GraphQLFloat,
   GraphQLID,
-  GraphQLInputType,
+  type GraphQLInputType,
   GraphQLInt,
   GraphQLSchema,
   GraphQLString,
@@ -14,14 +14,14 @@ import {
   isNonNullType,
   isScalarType,
   print,
-  SourceLocation,
+  type SourceLocation,
   typeFromAST,
   valueFromAST,
-  VariableDefinitionNode
+  type VariableDefinitionNode
 } from "graphql";
-import { addPath, computeLocations, ObjectPath } from "./ast";
-import { GraphQLError as GraphQLJITError } from "./error";
-import createInspect from "./inspect";
+import { addPath, computeLocations, type ObjectPath } from "./ast.js";
+import { GraphQLError as GraphQLJITError } from "./error.js";
+import createInspect from "./inspect.js";
 
 const inspect = createInspect();
 


### PR DESCRIPTION
Even with [new changes](https://github.com/zalando-incubator/graphql-jit/pull/252) it is buggy to use graphql-jit with esm. The problems are - file imports without extensions (e.g. "./execution"), internal package imports ("graphql/utils/Path"), and also directory imports ("graphql/language").

The other set of problems happen with esbuild (part of tsup) not being able to strip away type names from the build. For this it is required to mark the type imports with the type keyword in the import statements.

So, the PR fixes - 

1. use `.js` extension for imports that are not modules (relative imports and internal file / directory imports from packages)
2. add `type` modifier to all type only imports. This was done with the help of typescript 5's new feature [`verbatimModuleSyntax`](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax). We are not preserving this TSConfig option because it requires the package to be of `type: module` which is not the case for us.
3. Because we add extension, we configure jest to remove the `.js` extension so that Jest is able to import the ts file directly.

As a follow up PR, we can validate in CI using tsc or other tool that we don't export types without the `type` modifier.
