### PR TITLE
perf: micro optimizations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,7 +26,7 @@ export default tseslint.config(
       "no-sequences": "error",
       "no-template-curly-in-string": "error",
       "@typescript-eslint/no-empty-function": "error",
-      "@typescript-eslint/no-non-null-assertion": "error",
+      "@typescript-eslint/no-non-null-assertion": "warn",
 
       "@typescript-eslint/no-unused-vars": "warn",
 

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -99,154 +99,188 @@ function collectFieldsImpl(
   previousShouldInclude: string[] = [],
   parentResponsePath = ""
 ): FieldsAndNodes {
-  for (const selection of selectionSet.selections) {
-    switch (selection.kind) {
-      case Kind.FIELD: {
-        const name = getFieldEntryKey(selection);
-        if (!fields[name]) {
-          fields[name] = [];
-        }
-        const fieldNode: JitFieldNode = selection;
+  interface StackItem {
+    selectionSet: SelectionSetNode;
+    parentResponsePath: string;
+    previousShouldInclude: string[];
+  }
 
-        // the current path of the field
-        // This is used to generate per path skip/include code
-        // because the same field can be reached from different paths (e.g. fragment reuse)
-        const currentPath = joinSkipIncludePath(
-          parentResponsePath,
+  const stack: StackItem[] = [];
 
-          // use alias(instead of selection.name.value) if available as the responsePath used for lookup uses alias
-          name
-        );
+  stack.push({
+    selectionSet,
+    parentResponsePath,
+    previousShouldInclude
+  });
 
-        // `should include`s generated for the current fieldNode
-        const compiledSkipInclude = compileSkipInclude(
-          compilationContext,
-          selection
-        );
+  while (stack.length > 0) {
+    const { selectionSet, parentResponsePath, previousShouldInclude } =
+      stack.pop()!;
 
-        /**
-         * Carry over fragment's skip and include code
-         *
-         * fieldNode.__internalShouldInclude
-         * ---------------------------------
-         * When the parent field has a skip or include, the current one
-         * should be skipped if the parent is skipped in the path.
-         *
-         * previousShouldInclude
-         * ---------------------
-         * `should include`s from fragment spread and inline fragments
-         *
-         * compileSkipInclude(selection)
-         * -----------------------------
-         * `should include`s generated for the current fieldNode
-         */
-        if (compilationContext.options.useExperimentalPathBasedSkipInclude) {
-          if (!fieldNode.__internalShouldIncludePath)
-            fieldNode.__internalShouldIncludePath = {};
-
-          fieldNode.__internalShouldIncludePath[currentPath] =
-            joinShouldIncludeCompilations(
-              fieldNode.__internalShouldIncludePath?.[currentPath] ?? [],
-              previousShouldInclude,
-              [compiledSkipInclude]
-            );
-        } else {
-          // @deprecated
-          fieldNode.__internalShouldInclude = joinShouldIncludeCompilations(
-            fieldNode.__internalShouldInclude ?? [],
-            previousShouldInclude,
-            [compiledSkipInclude]
-          );
-        }
-        /**
-         * We augment the entire subtree as the parent object's skip/include
-         * directives influence the child even if the child doesn't have
-         * skip/include on it's own.
-         *
-         * Refer the function definition for example.
-         */
-        augmentFieldNodeTree(compilationContext, fieldNode, currentPath);
-
-        fields[name].push(fieldNode);
-        break;
-      }
-
-      case Kind.INLINE_FRAGMENT: {
-        if (
-          !doesFragmentConditionMatch(
+    for (const selection of selectionSet.selections) {
+      switch (selection.kind) {
+        case Kind.FIELD: {
+          collectFieldsForField({
             compilationContext,
-            selection,
-            runtimeType
-          )
-        ) {
-          continue;
-        }
-
-        // current fragment's shouldInclude
-        const compiledSkipInclude = compileSkipInclude(
-          compilationContext,
-          selection
-        );
-
-        // recurse
-        collectFieldsImpl(
-          compilationContext,
-          runtimeType,
-          selection.selectionSet,
-          fields,
-          visitedFragmentNames,
-          joinShouldIncludeCompilations(
-            // `should include`s from previous fragments
+            fields,
+            parentResponsePath,
             previousShouldInclude,
-            // current fragment's shouldInclude
-            [compiledSkipInclude]
-          ),
-          parentResponsePath
-        );
-        break;
-      }
-
-      case Kind.FRAGMENT_SPREAD: {
-        const fragName = selection.name.value;
-        if (visitedFragmentNames[fragName]) {
-          continue;
-        }
-        visitedFragmentNames[fragName] = true;
-        const fragment = compilationContext.fragments[fragName];
-        if (
-          !fragment ||
-          !doesFragmentConditionMatch(compilationContext, fragment, runtimeType)
-        ) {
-          continue;
+            selection
+          });
+          break;
         }
 
-        // current fragment's shouldInclude
-        const compiledSkipInclude = compileSkipInclude(
-          compilationContext,
-          selection
-        );
+        case Kind.INLINE_FRAGMENT: {
+          if (
+            !doesFragmentConditionMatch(
+              compilationContext,
+              selection,
+              runtimeType
+            )
+          ) {
+            continue;
+          }
 
-        // recurse
-        collectFieldsImpl(
-          compilationContext,
-          runtimeType,
-          fragment.selectionSet,
-          fields,
-          visitedFragmentNames,
-          joinShouldIncludeCompilations(
-            // `should include`s from previous fragments
-            previousShouldInclude,
-            // current fragment's shouldInclude
-            [compiledSkipInclude]
-          ),
-          parentResponsePath
-        );
+          // current fragment's shouldInclude
+          const compiledSkipInclude = compileSkipInclude(
+            compilationContext,
+            selection
+          );
 
-        break;
+          // push to stack
+          stack.push({
+            selectionSet: selection.selectionSet,
+            parentResponsePath: parentResponsePath,
+            previousShouldInclude: joinShouldIncludeCompilations(
+              // `should include`s from previous fragments
+              previousShouldInclude,
+              // current fragment's shouldInclude
+              [compiledSkipInclude]
+            )
+          });
+          break;
+        }
+
+        case Kind.FRAGMENT_SPREAD: {
+          const fragName = selection.name.value;
+          if (visitedFragmentNames[fragName]) {
+            continue;
+          }
+          visitedFragmentNames[fragName] = true;
+          const fragment = compilationContext.fragments[fragName];
+          if (
+            !fragment ||
+            !doesFragmentConditionMatch(
+              compilationContext,
+              fragment,
+              runtimeType
+            )
+          ) {
+            continue;
+          }
+
+          // current fragment's shouldInclude
+          const compiledSkipInclude = compileSkipInclude(
+            compilationContext,
+            selection
+          );
+
+          // push to stack
+          stack.push({
+            selectionSet: fragment.selectionSet,
+            parentResponsePath,
+            previousShouldInclude: joinShouldIncludeCompilations(
+              // `should include`s from previous fragments
+              previousShouldInclude,
+              // current fragment's shouldInclude
+              [compiledSkipInclude]
+            )
+          });
+          break;
+        }
       }
     }
   }
+
   return fields;
+}
+
+function collectFieldsForField({
+  compilationContext,
+  fields,
+  parentResponsePath,
+  previousShouldInclude,
+  selection
+}: {
+  compilationContext: CompilationContext;
+  fields: FieldsAndNodes;
+  parentResponsePath: string;
+  previousShouldInclude: string[];
+  selection: FieldNode;
+}) {
+  const name = getFieldEntryKey(selection);
+  if (!fields[name]) {
+    fields[name] = [];
+  }
+  const fieldNode: JitFieldNode = selection;
+
+  // the current path of the field
+  // This is used to generate per path skip/include code
+  // because the same field can be reached from different paths (e.g. fragment reuse)
+  const currentPath = joinSkipIncludePath(
+    parentResponsePath,
+
+    // use alias(instead of selection.name.value) if available as the responsePath used for lookup uses alias
+    name
+  );
+
+  // `should include`s generated for the current fieldNode
+  const compiledSkipInclude = compileSkipInclude(compilationContext, selection);
+
+  /**
+   * Carry over fragment's skip and include code
+   *
+   * fieldNode.__internalShouldInclude
+   * ---------------------------------
+   * When the parent field has a skip or include, the current one
+   * should be skipped if the parent is skipped in the path.
+   *
+   * previousShouldInclude
+   * ---------------------
+   * `should include`s from fragment spread and inline fragments
+   *
+   * compileSkipInclude(selection)
+   * -----------------------------
+   * `should include`s generated for the current fieldNode
+   */
+  if (compilationContext.options.useExperimentalPathBasedSkipInclude) {
+    if (!fieldNode.__internalShouldIncludePath)
+      fieldNode.__internalShouldIncludePath = {};
+
+    fieldNode.__internalShouldIncludePath[currentPath] =
+      joinShouldIncludeCompilations(
+        fieldNode.__internalShouldIncludePath?.[currentPath] ?? [],
+        previousShouldInclude,
+        [compiledSkipInclude]
+      );
+  } else {
+    // @deprecated
+    fieldNode.__internalShouldInclude = joinShouldIncludeCompilations(
+      fieldNode.__internalShouldInclude ?? [],
+      previousShouldInclude,
+      [compiledSkipInclude]
+    );
+  }
+  /**
+   * We augment the entire subtree as the parent object's skip/include
+   * directives influence the child even if the child doesn't have
+   * skip/include on it's own.
+   *
+   * Refer the function definition for example.
+   */
+  augmentFieldNodeTree(compilationContext, fieldNode, currentPath);
+
+  fields[name].push(fieldNode);
 }
 
 /**
@@ -303,66 +337,99 @@ function augmentFieldNodeTree(
   parentResponsePath: string
 ) {
   for (const selection of rootFieldNode.selectionSet?.selections ?? []) {
-    handle(rootFieldNode, selection, false, parentResponsePath);
-  }
+    /**
+     * Traverse through sub-selection and combine `shouldInclude`s
+     * from parent and current ones.
+     */
+    interface StackItem {
+      parentFieldNode: JitFieldNode;
+      selection: SelectionNode;
+      comesFromFragmentSpread: boolean;
+      parentResponsePath: string;
+    }
 
-  /**
-   * Recursively traverse through sub-selection and combine `shouldInclude`s
-   * from parent and current ones.
-   */
-  function handle(
-    parentFieldNode: JitFieldNode,
-    selection: SelectionNode,
-    comesFromFragmentSpread = false,
-    parentResponsePath: string
-  ) {
-    switch (selection.kind) {
-      case Kind.FIELD: {
-        const jitFieldNode: JitFieldNode = selection;
-        const currentPath = joinSkipIncludePath(
-          parentResponsePath,
+    const stack: StackItem[] = [];
 
-          // use alias(instead of selection.name.value) if available as the responsePath used for lookup uses alias
-          getFieldEntryKey(jitFieldNode)
-        );
+    stack.push({
+      parentFieldNode: rootFieldNode,
+      selection,
+      comesFromFragmentSpread: false,
+      parentResponsePath
+    });
 
-        if (!comesFromFragmentSpread) {
-          if (compilationContext.options.useExperimentalPathBasedSkipInclude) {
-            if (!jitFieldNode.__internalShouldIncludePath)
-              jitFieldNode.__internalShouldIncludePath = {};
+    while (stack.length > 0) {
+      const {
+        parentFieldNode,
+        selection,
+        comesFromFragmentSpread,
+        parentResponsePath
+      } = stack.pop()!;
 
-            jitFieldNode.__internalShouldIncludePath[currentPath] =
-              joinShouldIncludeCompilations(
-                parentFieldNode.__internalShouldIncludePath?.[
-                  parentResponsePath
-                ] ?? [],
-                jitFieldNode.__internalShouldIncludePath?.[currentPath] ?? []
-              );
-          } else {
-            // @deprecated
-            jitFieldNode.__internalShouldInclude =
-              joinShouldIncludeCompilations(
-                parentFieldNode.__internalShouldInclude ?? [],
-                jitFieldNode.__internalShouldInclude ?? []
-              );
+      switch (selection.kind) {
+        case Kind.FIELD: {
+          const jitFieldNode: JitFieldNode = selection;
+          const currentPath = joinSkipIncludePath(
+            parentResponsePath,
+
+            // use alias(instead of selection.name.value) if available as the responsePath used for lookup uses alias
+            getFieldEntryKey(jitFieldNode)
+          );
+
+          if (!comesFromFragmentSpread) {
+            if (
+              compilationContext.options.useExperimentalPathBasedSkipInclude
+            ) {
+              if (!jitFieldNode.__internalShouldIncludePath)
+                jitFieldNode.__internalShouldIncludePath = {};
+
+              jitFieldNode.__internalShouldIncludePath[currentPath] =
+                joinShouldIncludeCompilations(
+                  parentFieldNode.__internalShouldIncludePath?.[
+                    parentResponsePath
+                  ] ?? [],
+                  jitFieldNode.__internalShouldIncludePath?.[currentPath] ?? []
+                );
+            } else {
+              // @deprecated
+              jitFieldNode.__internalShouldInclude =
+                joinShouldIncludeCompilations(
+                  parentFieldNode.__internalShouldInclude ?? [],
+                  jitFieldNode.__internalShouldInclude ?? []
+                );
+            }
           }
+          // go further down the query tree
+          for (const selection of jitFieldNode.selectionSet?.selections ?? []) {
+            stack.push({
+              parentFieldNode: jitFieldNode,
+              selection,
+              comesFromFragmentSpread: false,
+              parentResponsePath: currentPath
+            });
+          }
+          break;
         }
-        // go further down the query tree
-        for (const selection of jitFieldNode.selectionSet?.selections ?? []) {
-          handle(jitFieldNode, selection, false, currentPath);
+        case Kind.INLINE_FRAGMENT: {
+          for (const subSelection of selection.selectionSet.selections) {
+            stack.push({
+              parentFieldNode,
+              selection: subSelection,
+              comesFromFragmentSpread: true,
+              parentResponsePath
+            });
+          }
+          break;
         }
-        break;
-      }
-      case Kind.INLINE_FRAGMENT: {
-        for (const subSelection of selection.selectionSet.selections) {
-          handle(parentFieldNode, subSelection, true, parentResponsePath);
-        }
-        break;
-      }
-      case Kind.FRAGMENT_SPREAD: {
-        const fragment = compilationContext.fragments[selection.name.value];
-        for (const subSelection of fragment.selectionSet.selections) {
-          handle(parentFieldNode, subSelection, true, parentResponsePath);
+        case Kind.FRAGMENT_SPREAD: {
+          const fragment = compilationContext.fragments[selection.name.value];
+          for (const subSelection of fragment.selectionSet.selections) {
+            stack.push({
+              parentFieldNode,
+              selection: subSelection,
+              comesFromFragmentSpread: true,
+              parentResponsePath
+            });
+          }
         }
       }
     }
@@ -427,6 +494,11 @@ function compileSkipInclude(
   compilationContext: CompilationContext,
   node: SelectionNode
 ): string {
+  // minor optimization to avoid compilation if there are no directives
+  if (node.directives == null || node.directives.length < 1) {
+    return "true";
+  }
+
   const { skipValue, includeValue } = compileSkipIncludeDirectiveValues(
     compilationContext,
     node

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -1,0 +1,12 @@
+export function genFn() {
+  let body = "";
+
+  function add(str: string) {
+    body += str + "\n";
+    return add;
+  }
+
+  add.toString = () => body;
+
+  return add;
+}

--- a/src/resolve-info.ts
+++ b/src/resolve-info.ts
@@ -1,4 +1,4 @@
-import genFn from "generate-function";
+import { genFn } from "./generate";
 import {
   doTypesOverlap,
   type FieldNode,

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -1,4 +1,4 @@
-import genFn from "generate-function";
+import { genFn } from "./generate";
 import {
   GraphQLBoolean,
   GraphQLError,


### PR DESCRIPTION
A few performance improvements to compilation based on micro-optimizations / benchmarks - 

1. string concatenation `body += ` seems to be faster than `[].join("\n")` that is used by generate-function.
2. Prefer looping over recursion as tail calls are not optimized in v8 as of this writing
3. Add memoization to simple functions - e.g. joinOriginPaths
4. Restructure compilations of skip/include to a `string[][]` and avoid the unnecessary string manipulation. Reduces complexity - simplifies filtering of unwanted `true`s and code generation.

Next set of optimizations will follow in separate PRs.

Observations with this - 

For a very big query (1100 lines formatted, 30+ fragments, 40+ variables, max depth - 8) that takes 1.7s to compile, this PR brings it down to around 1.4s - around 17% faster.